### PR TITLE
fix(build): COLLECTION_DEFINITION_FOLDER and VIEWS_DEFINITION_FOLDER to support both relative and absolute path

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,19 +189,29 @@ const joinPath = (folder, path) => (isAbsolute(folder) ? join(folder, path) : jo
 const validCrudFolder = path => !['.', '..'].includes(path) && /\.js(on)?$/.test(path)
 
 async function setupCruds(fastify) {
-  const collections = readdirSync(fastify.config.COLLECTION_DEFINITION_FOLDER)
-    .filter(validCrudFolder)
-    .map(path => joinPath(fastify.config.COLLECTION_DEFINITION_FOLDER, path))
-    .map(require)
+  let collections = []
+  try {
+    collections = readdirSync(fastify.config.COLLECTION_DEFINITION_FOLDER)
+      .filter(validCrudFolder)
+      .map(path => joinPath(fastify.config.COLLECTION_DEFINITION_FOLDER, path))
+      .map(require)
+  } catch (error) {
+    throw new Error('The folder defined in COLLECTION_DEFINITION_FOLDER is not found. Are you sure it exists?', error)
+  }
 
   fastify.decorate('collections', collections)
 
   const viewsFolder = fastify.config.VIEWS_DEFINITION_FOLDER
   if (viewsFolder) {
-    const views = readdirSync(viewsFolder)
-      .filter(validCrudFolder)
-      .map(path => joinPath(viewsFolder, path))
-      .map(require)
+    let views = []
+    try {
+      views = readdirSync(viewsFolder)
+        .filter(validCrudFolder)
+        .map(path => joinPath(viewsFolder, path))
+        .map(require)
+    } catch (error) {
+      throw new Error('The folder defined in VIEWS_DEFINITION_FOLDER is not found. Are you sure it exists?', error)
+    }
 
     fastify.decorate('views', views)
   }

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const AjvCompiler = require('@fastify/ajv-compiler')
 const ajvFormats = require('ajv-formats')
 
 const { readdirSync } = require('fs')
-const { join } = require('path')
+const { isAbsolute, join } = require('path')
 const { omit } = require('ramda')
 
 const myPackage = require('./package')
@@ -185,12 +185,13 @@ function getCollectionNameFromEndpoint(endpointBasePath) {
   return endpointBasePath.replace('/', '').replace(/\//g, '-')
 }
 
+const joinPath = (folder, path) => (isAbsolute(folder) ? join(folder, path) : join(__dirname, folder, path))
 const validCrudFolder = path => !['.', '..'].includes(path) && /\.js(on)?$/.test(path)
 
 async function setupCruds(fastify) {
   const collections = readdirSync(fastify.config.COLLECTION_DEFINITION_FOLDER)
     .filter(validCrudFolder)
-    .map(path => join(fastify.config.COLLECTION_DEFINITION_FOLDER, path))
+    .map(path => joinPath(fastify.config.COLLECTION_DEFINITION_FOLDER, path))
     .map(require)
 
   fastify.decorate('collections', collections)
@@ -199,7 +200,7 @@ async function setupCruds(fastify) {
   if (viewsFolder) {
     const views = readdirSync(viewsFolder)
       .filter(validCrudFolder)
-      .map(path => join(viewsFolder, path))
+      .map(path => joinPath(viewsFolder, path))
       .map(require)
 
     fastify.decorate('views', views)

--- a/index.js
+++ b/index.js
@@ -196,7 +196,10 @@ async function setupCruds(fastify) {
       .map(path => joinPath(fastify.config.COLLECTION_DEFINITION_FOLDER, path))
       .map(require)
   } catch (error) {
-    throw new Error('The folder defined in COLLECTION_DEFINITION_FOLDER is not found. Are you sure it exists?', error)
+    throw new Error(`An error occurred loading the Collections definitions. 
+Verify if the folder defined in COLLECTION_DEFINITION_FOLDER is valid and if the files includes valid definitions. 
+${error}
+      `)
   }
 
   fastify.decorate('collections', collections)
@@ -210,7 +213,10 @@ async function setupCruds(fastify) {
         .map(path => joinPath(viewsFolder, path))
         .map(require)
     } catch (error) {
-      throw new Error('The folder defined in VIEWS_DEFINITION_FOLDER is not found. Are you sure it exists?', error)
+      throw new Error(`An error occurred loading the Views definitions. 
+Verify if the folder defined in VIEWS_DEFINITION_FOLDER is valid and if the files includes valid definitions. 
+${error}
+      `)
     }
 
     fastify.decorate('views', views)

--- a/tests/envSchema.test.js
+++ b/tests/envSchema.test.js
@@ -32,10 +32,8 @@ tap.test('envSchema tests', async t => {
     fastify = await lc39('./index.js', {
       envVariables: {
         MONGODB_URL: mongoURL,
-        // Absolute path
         COLLECTION_DEFINITION_FOLDER: path.join(__dirname, 'emptyCollectionDefinitions'),
-        // Relative path
-        VIEWS_DEFINITION_FOLDER: 'tests/emptyViewsDefinitions',
+        VIEWS_DEFINITION_FOLDER: path.join(__dirname, 'emptyViewsDefinitions'),
         USER_ID_HEADER_KEY: 'userid',
         ...envs,
       },
@@ -53,6 +51,16 @@ tap.test('envSchema tests', async t => {
 
   t.test('Valid base schema with none provider', async t => {
     t.resolves(startFastify({ KMS_PROVIDER: 'none' }))
+  })
+
+  t.test('Valid base schema with relative paths', async t => {
+    t.resolves(
+      startFastify(
+        {
+          COLLECTION_DEFINITION_FOLDER: 'tests/emptyCollectionDefinitions',
+          VIEWS_DEFINITION_FOLDER: 'tests/emptyViewsDefinitions' }
+      )
+    )
   })
 
   t.test('Missing local master key path', async t => {

--- a/tests/envSchema.test.js
+++ b/tests/envSchema.test.js
@@ -32,7 +32,10 @@ tap.test('envSchema tests', async t => {
     fastify = await lc39('./index.js', {
       envVariables: {
         MONGODB_URL: mongoURL,
+        // Absolute path
         COLLECTION_DEFINITION_FOLDER: path.join(__dirname, 'emptyCollectionDefinitions'),
+        // Relative path
+        VIEWS_DEFINITION_FOLDER: 'tests/emptyViewsDefinitions',
         USER_ID_HEADER_KEY: 'userid',
         ...envs,
       },


### PR DESCRIPTION
<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

## Pull Request Type
<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

This Pull Request fix a problem noted in #27 .

Add a quick function that build the path, based on the `isAbsolute` function. With this, the environment variables COLLECTION_DEFINITION_FOLDER and VIEWS_DEFINITION_FOLDER can be populated with each relative and absolute path, thus:
- making the `default.env` file becoming necessary to run the CRUD Service without further modifications;
- simplifying the process of generating your own environment variables;

Test has been included making sure that these variables works both ways.

## PR Checklist

<!-- TODO: Include update for the CONTRIBUTING file up-to-date regarding information about the commit -->
- [X] The commit message follows our guidelines included in the [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-submit-a-pr)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Use this space to include more information about your pull request. If you don't need to add anything, feel free to remove this section. -->