### PR TITLE
[bugfix] $addToSet, $pull and $set now accepts additional Properties if set to true

### DIFF
--- a/lib/JSONSchemaGenerator.js
+++ b/lib/JSONSchemaGenerator.js
@@ -1097,7 +1097,7 @@ function propertiesPatchCommandsValidation(
     [PULLCMD]: {
       type: 'object',
       properties: arrayPropertiesWithMongoConditions,
-      ...Object.keys(arrayPatternProperties).length > 0
+      ...Object.keys(arrayPatternPropertiesWithMongoConditions).length > 0
         ? { patternProperties: arrayPatternPropertiesWithMongoConditions }
         : {},
       additionalProperties: false,
@@ -1105,7 +1105,7 @@ function propertiesPatchCommandsValidation(
     [ADDTOSETCMD]: {
       type: 'object',
       properties: arrayPropertiesWithMongoConditions,
-      ...Object.keys(arrayPatternProperties).length > 0
+      ...Object.keys(arrayPatternPropertiesWithMongoConditions).length > 0
         ? { patternProperties: arrayPatternPropertiesWithMongoConditions }
         : {},
       additionalProperties: false,
@@ -1223,6 +1223,11 @@ function getArrayPatternProperties(rawPatternProperties = {}) {
   const withMongoDBConditionsSupport = {}
   const withoutMongoDBConditionsSupport = {}
   Object.keys(rawPatternProperties).forEach((key) => {
+    if (typeof rawPatternProperties[key] === 'boolean' && rawPatternProperties[key]) {
+      withMongoDBConditionsSupport[key] = { oneOf: [{}, mongoOperatorSchema] }
+      withoutMongoDBConditionsSupport[key] = {}
+      return
+    }
     if (rawPatternProperties[key].type !== JSON_SCHEMA_ARRAY_TYPE) {
       return
     }

--- a/lib/QueryParser.js
+++ b/lib/QueryParser.js
@@ -499,7 +499,11 @@ function getRawSchemaFieldPath(fieldPath, rawSchemas = {}) {
     return paths[fieldPath]
   }
 
-  const patternProperties = Object.keys(rawSchemas.patternProperties || {})
+  // we do this sort to match the most strictest regex
+  const patternProperties = Object
+    .keys(rawSchemas.patternProperties ?? {})
+    .sort((firstRegex, secondRegex) => secondRegex.length - firstRegex.length)
+
   const fromPatternProperties = patternProperties.find(pattern => new RegExp(pattern).test(fieldPath))
   if (fromPatternProperties) {
     return rawSchemas.patternProperties[fromPatternProperties]
@@ -605,4 +609,5 @@ function countTextOccurrences(query) {
   return occurrences.length
 }
 
+// eslint-disable-next-line max-lines
 module.exports = QueryParser

--- a/lib/QueryParser.js
+++ b/lib/QueryParser.js
@@ -500,6 +500,8 @@ function getRawSchemaFieldPath(fieldPath, rawSchemas = {}) {
   }
 
   // we do this sort to match the most strictest regex
+  // in some cases we could have a shorter regex matching the pattern
+  // and returning the element.
   const patternProperties = Object
     .keys(rawSchemas.patternProperties ?? {})
     .sort((firstRegex, secondRegex) => secondRegex.length - firstRegex.length)

--- a/lib/QueryParser.js
+++ b/lib/QueryParser.js
@@ -499,7 +499,7 @@ function getRawSchemaFieldPath(fieldPath, rawSchemas = {}) {
     return paths[fieldPath]
   }
 
-  // we do this sort to match the most strictest regex
+  // we do this sort to match the strictest regex
   // in some cases we could have a shorter regex matching the pattern
   // and returning the element.
   const patternProperties = Object

--- a/lib/generatePathFieldsForRawSchema.js
+++ b/lib/generatePathFieldsForRawSchema.js
@@ -32,10 +32,15 @@ function getFieldJsonSchemaByTypeCompatibility(field) {
       items: {
         type: JSON_SCHEMA_OBJECT_TYPE,
         properties: field.items.schema.properties,
+        additionalProperties: field.items.schema.additionalProperties,
       },
     }
   }
-  return { type: JSON_SCHEMA_OBJECT_TYPE, properties: field.schema.properties }
+  return {
+    type: JSON_SCHEMA_OBJECT_TYPE,
+    properties: field.schema.properties,
+    additionalProperties: field.schema.additionalProperties,
+  }
 }
 
 function getFieldJsonSchemaByType(jsonSchema) {
@@ -45,10 +50,15 @@ function getFieldJsonSchemaByType(jsonSchema) {
       items: {
         type: JSON_SCHEMA_OBJECT_TYPE,
         properties: jsonSchema.items.properties,
+        additionalProperties: jsonSchema.items.additionalProperties,
       },
     }
   }
-  return { type: JSON_SCHEMA_OBJECT_TYPE, properties: jsonSchema.properties }
+  return {
+    type: JSON_SCHEMA_OBJECT_TYPE,
+    properties: jsonSchema.properties,
+    additionalProperties: jsonSchema.additionalProperties,
+  }
 }
 
 const generatePathFieldsForRawSchemaCompatibility = (logger, collectionDefinition) => collectionDefinition

--- a/tests/expectedSchemas/booksChangeStateManySchema.js
+++ b/tests/expectedSchemas/booksChangeStateManySchema.js
@@ -373,6 +373,7 @@ module.exports = {
                   },
                 },
               },
+              'additionalProperties': false,
             },
             'attachments\\.\\d+\\.name$': {
               'type': 'string',

--- a/tests/expectedSchemas/booksNewChangeStateManySchema.js
+++ b/tests/expectedSchemas/booksNewChangeStateManySchema.js
@@ -373,6 +373,7 @@ module.exports = {
                   },
                 },
               },
+              'additionalProperties': false,
             },
             'attachments\\.\\d+\\.name$': {
               'type': 'string',

--- a/tests/expectedSchemas/booksNewPatchBulkSchema.js
+++ b/tests/expectedSchemas/booksNewPatchBulkSchema.js
@@ -304,6 +304,7 @@ module.exports = {
                   },
                 },
               },
+              'additionalProperties': false,
             },
             'attachments\\.\\d+\\.name$': {
               'type': 'string',
@@ -860,6 +861,7 @@ module.exports = {
                       },
                     },
                   },
+                  'additionalProperties': false,
                 },
                 'attachments\\.\\d+\\.name$': {
                   'type': 'string',

--- a/tests/expectedSchemas/booksNewPatchBulkSchema.js
+++ b/tests/expectedSchemas/booksNewPatchBulkSchema.js
@@ -1201,12 +1201,15 @@ module.exports = {
                 },
               },
               'patternProperties': {
+                'metadata\\.somethingArrayObject\\.\\d+\\..+$': {},
+                'metadata\\.somethingObject\\..+$': {},
                 'metadata\\.exampleArrayOfArray\\.\\d+$': {
                   'type': 'string',
                 },
                 'attachments\\.\\d+\\.neastedArr$': {
                   'type': 'number',
                 },
+                'attachments\\.\\d+\\.additionalInfo\\..+$': {},
                 'attachments\\.\\d+\\.more$': {
                   'type': 'string',
                 },
@@ -1321,6 +1324,28 @@ module.exports = {
                 },
               },
               'patternProperties': {
+                'metadata\\.somethingArrayObject\\.\\d+\\..+$': {
+                  'oneOf': [
+                    {},
+                    {
+                      'type': 'object',
+                      'patternProperties': {
+                        '^$': {},
+                      },
+                    },
+                  ],
+                },
+                'metadata\\.somethingObject\\..+$': {
+                  'oneOf': [
+                    {},
+                    {
+                      'type': 'object',
+                      'patternProperties': {
+                        '^$': {},
+                      },
+                    },
+                  ],
+                },
                 'metadata\\.exampleArrayOfArray\\.\\d+$': {
                   'oneOf': [
                     {
@@ -1339,6 +1364,17 @@ module.exports = {
                     {
                       'type': 'number',
                     },
+                    {
+                      'type': 'object',
+                      'patternProperties': {
+                        '^$': {},
+                      },
+                    },
+                  ],
+                },
+                'attachments\\.\\d+\\.additionalInfo\\..+$': {
+                  'oneOf': [
+                    {},
                     {
                       'type': 'object',
                       'patternProperties': {
@@ -1471,6 +1507,28 @@ module.exports = {
                 },
               },
               'patternProperties': {
+                'metadata\\.somethingArrayObject\\.\\d+\\..+$': {
+                  'oneOf': [
+                    {},
+                    {
+                      'type': 'object',
+                      'patternProperties': {
+                        '^$': {},
+                      },
+                    },
+                  ],
+                },
+                'metadata\\.somethingObject\\..+$': {
+                  'oneOf': [
+                    {},
+                    {
+                      'type': 'object',
+                      'patternProperties': {
+                        '^$': {},
+                      },
+                    },
+                  ],
+                },
                 'metadata\\.exampleArrayOfArray\\.\\d+$': {
                   'oneOf': [
                     {
@@ -1489,6 +1547,17 @@ module.exports = {
                     {
                       'type': 'number',
                     },
+                    {
+                      'type': 'object',
+                      'patternProperties': {
+                        '^$': {},
+                      },
+                    },
+                  ],
+                },
+                'attachments\\.\\d+\\.additionalInfo\\..+$': {
+                  'oneOf': [
+                    {},
                     {
                       'type': 'object',
                       'patternProperties': {

--- a/tests/expectedSchemas/booksNewPatchManySchema.js
+++ b/tests/expectedSchemas/booksNewPatchManySchema.js
@@ -667,6 +667,7 @@ module.exports = {
                 },
               },
             },
+            'additionalProperties': false,
           },
           'attachments\\.\\d+\\.name$': {
             'type': 'string',

--- a/tests/expectedSchemas/booksNewPatchManySchema.js
+++ b/tests/expectedSchemas/booksNewPatchManySchema.js
@@ -1008,12 +1008,15 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {},
+          'metadata\\.somethingObject\\..+$': {},
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'type': 'string',
           },
           'attachments\\.\\d+\\.neastedArr$': {
             'type': 'number',
           },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {},
           'attachments\\.\\d+\\.more$': {
             'type': 'string',
           },
@@ -1128,6 +1131,28 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'metadata\\.somethingObject\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'oneOf': [
               {
@@ -1146,6 +1171,17 @@ module.exports = {
               {
                 'type': 'number',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {
@@ -1278,6 +1314,28 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'metadata\\.somethingObject\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'oneOf': [
               {
@@ -1296,6 +1354,17 @@ module.exports = {
               {
                 'type': 'number',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {

--- a/tests/expectedSchemas/booksNewPatchSchema.js
+++ b/tests/expectedSchemas/booksNewPatchSchema.js
@@ -669,6 +669,7 @@ module.exports = {
                 },
               },
             },
+            'additionalProperties': false,
           },
           'attachments\\.\\d+\\.name$': {
             'type': 'string',

--- a/tests/expectedSchemas/booksNewPatchSchema.js
+++ b/tests/expectedSchemas/booksNewPatchSchema.js
@@ -1010,12 +1010,15 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {},
+          'metadata\\.somethingObject\\..+$': {},
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'type': 'string',
           },
           'attachments\\.\\d+\\.neastedArr$': {
             'type': 'number',
           },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {},
           'attachments\\.\\d+\\.more$': {
             'type': 'string',
           },
@@ -1130,6 +1133,28 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'metadata\\.somethingObject\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'oneOf': [
               {
@@ -1148,6 +1173,17 @@ module.exports = {
               {
                 'type': 'number',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {
@@ -1280,6 +1316,28 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'metadata\\.somethingObject\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'oneOf': [
               {
@@ -1298,6 +1356,17 @@ module.exports = {
               {
                 'type': 'number',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {

--- a/tests/expectedSchemas/booksNewUpsertOneSchema.js
+++ b/tests/expectedSchemas/booksNewUpsertOneSchema.js
@@ -1000,12 +1000,15 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {},
+          'metadata\\.somethingObject\\..+$': {},
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'type': 'string',
           },
           'attachments\\.\\d+\\.neastedArr$': {
             'type': 'number',
           },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {},
           'attachments\\.\\d+\\.more$': {
             'type': 'string',
           },
@@ -1120,6 +1123,28 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'metadata\\.somethingObject\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'oneOf': [
               {
@@ -1138,6 +1163,17 @@ module.exports = {
               {
                 'type': 'number',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {
@@ -1270,6 +1306,28 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'metadata\\.somethingObject\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'oneOf': [
               {
@@ -1288,6 +1346,17 @@ module.exports = {
               {
                 'type': 'number',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {

--- a/tests/expectedSchemas/booksNewUpsertOneSchema.js
+++ b/tests/expectedSchemas/booksNewUpsertOneSchema.js
@@ -659,6 +659,7 @@ module.exports = {
                 },
               },
             },
+            'additionalProperties': false,
           },
           'attachments\\.\\d+\\.name$': {
             'type': 'string',

--- a/tests/expectedSchemas/booksPatchBulkSchema.js
+++ b/tests/expectedSchemas/booksPatchBulkSchema.js
@@ -304,6 +304,7 @@ module.exports = {
                   },
                 },
               },
+              'additionalProperties': false,
             },
             'attachments\\.\\d+\\.name$': {
               'type': 'string',
@@ -860,6 +861,7 @@ module.exports = {
                       },
                     },
                   },
+                  'additionalProperties': false,
                 },
                 'attachments\\.\\d+\\.name$': {
                   'type': 'string',

--- a/tests/expectedSchemas/booksPatchBulkSchema.js
+++ b/tests/expectedSchemas/booksPatchBulkSchema.js
@@ -1201,12 +1201,15 @@ module.exports = {
                 },
               },
               'patternProperties': {
+                'metadata\\.somethingArrayObject\\.\\d+\\..+$': {},
+                'metadata\\.somethingObject\\..+$': {},
                 'metadata\\.exampleArrayOfArray\\.\\d+$': {
                   'type': 'string',
                 },
                 'attachments\\.\\d+\\.neastedArr$': {
                   'type': 'number',
                 },
+                'attachments\\.\\d+\\.additionalInfo\\..+$': {},
                 'attachments\\.\\d+\\.more$': {
                   'type': 'string',
                 },
@@ -1321,6 +1324,28 @@ module.exports = {
                 },
               },
               'patternProperties': {
+                'metadata\\.somethingArrayObject\\.\\d+\\..+$': {
+                  'oneOf': [
+                    {},
+                    {
+                      'type': 'object',
+                      'patternProperties': {
+                        '^$': {},
+                      },
+                    },
+                  ],
+                },
+                'metadata\\.somethingObject\\..+$': {
+                  'oneOf': [
+                    {},
+                    {
+                      'type': 'object',
+                      'patternProperties': {
+                        '^$': {},
+                      },
+                    },
+                  ],
+                },
                 'metadata\\.exampleArrayOfArray\\.\\d+$': {
                   'oneOf': [
                     {
@@ -1339,6 +1364,17 @@ module.exports = {
                     {
                       'type': 'number',
                     },
+                    {
+                      'type': 'object',
+                      'patternProperties': {
+                        '^$': {},
+                      },
+                    },
+                  ],
+                },
+                'attachments\\.\\d+\\.additionalInfo\\..+$': {
+                  'oneOf': [
+                    {},
                     {
                       'type': 'object',
                       'patternProperties': {
@@ -1471,6 +1507,28 @@ module.exports = {
                 },
               },
               'patternProperties': {
+                'metadata\\.somethingArrayObject\\.\\d+\\..+$': {
+                  'oneOf': [
+                    {},
+                    {
+                      'type': 'object',
+                      'patternProperties': {
+                        '^$': {},
+                      },
+                    },
+                  ],
+                },
+                'metadata\\.somethingObject\\..+$': {
+                  'oneOf': [
+                    {},
+                    {
+                      'type': 'object',
+                      'patternProperties': {
+                        '^$': {},
+                      },
+                    },
+                  ],
+                },
                 'metadata\\.exampleArrayOfArray\\.\\d+$': {
                   'oneOf': [
                     {
@@ -1489,6 +1547,17 @@ module.exports = {
                     {
                       'type': 'number',
                     },
+                    {
+                      'type': 'object',
+                      'patternProperties': {
+                        '^$': {},
+                      },
+                    },
+                  ],
+                },
+                'attachments\\.\\d+\\.additionalInfo\\..+$': {
+                  'oneOf': [
+                    {},
                     {
                       'type': 'object',
                       'patternProperties': {

--- a/tests/expectedSchemas/booksPatchManySchema.js
+++ b/tests/expectedSchemas/booksPatchManySchema.js
@@ -667,6 +667,7 @@ module.exports = {
                 },
               },
             },
+            'additionalProperties': false,
           },
           'attachments\\.\\d+\\.name$': {
             'type': 'string',

--- a/tests/expectedSchemas/booksPatchManySchema.js
+++ b/tests/expectedSchemas/booksPatchManySchema.js
@@ -1008,12 +1008,15 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {},
+          'metadata\\.somethingObject\\..+$': {},
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'type': 'string',
           },
           'attachments\\.\\d+\\.neastedArr$': {
             'type': 'number',
           },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {},
           'attachments\\.\\d+\\.more$': {
             'type': 'string',
           },
@@ -1128,6 +1131,28 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'metadata\\.somethingObject\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'oneOf': [
               {
@@ -1146,6 +1171,17 @@ module.exports = {
               {
                 'type': 'number',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {
@@ -1278,6 +1314,28 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'metadata\\.somethingObject\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'oneOf': [
               {
@@ -1296,6 +1354,17 @@ module.exports = {
               {
                 'type': 'number',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {

--- a/tests/expectedSchemas/booksPatchSchema.js
+++ b/tests/expectedSchemas/booksPatchSchema.js
@@ -669,6 +669,7 @@ module.exports = {
                 },
               },
             },
+            'additionalProperties': false,
           },
           'attachments\\.\\d+\\.name$': {
             'type': 'string',

--- a/tests/expectedSchemas/booksPatchSchema.js
+++ b/tests/expectedSchemas/booksPatchSchema.js
@@ -1010,12 +1010,15 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {},
+          'metadata\\.somethingObject\\..+$': {},
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'type': 'string',
           },
           'attachments\\.\\d+\\.neastedArr$': {
             'type': 'number',
           },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {},
           'attachments\\.\\d+\\.more$': {
             'type': 'string',
           },
@@ -1130,6 +1133,28 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'metadata\\.somethingObject\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'oneOf': [
               {
@@ -1148,6 +1173,17 @@ module.exports = {
               {
                 'type': 'number',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {
@@ -1280,6 +1316,28 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'metadata\\.somethingObject\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'oneOf': [
               {
@@ -1298,6 +1356,17 @@ module.exports = {
               {
                 'type': 'number',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {

--- a/tests/expectedSchemas/booksUpsertOneSchema.js
+++ b/tests/expectedSchemas/booksUpsertOneSchema.js
@@ -1000,12 +1000,15 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {},
+          'metadata\\.somethingObject\\..+$': {},
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'type': 'string',
           },
           'attachments\\.\\d+\\.neastedArr$': {
             'type': 'number',
           },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {},
           'attachments\\.\\d+\\.more$': {
             'type': 'string',
           },
@@ -1120,6 +1123,28 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'metadata\\.somethingObject\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'oneOf': [
               {
@@ -1138,6 +1163,17 @@ module.exports = {
               {
                 'type': 'number',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {
@@ -1270,6 +1306,28 @@ module.exports = {
           },
         },
         'patternProperties': {
+          'metadata\\.somethingArrayObject\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'metadata\\.somethingObject\\..+$': {
+            'oneOf': [
+              {},
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+$': {
             'oneOf': [
               {
@@ -1288,6 +1346,17 @@ module.exports = {
               {
                 'type': 'number',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'attachments\\.\\d+\\.additionalInfo\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {

--- a/tests/expectedSchemas/booksUpsertOneSchema.js
+++ b/tests/expectedSchemas/booksUpsertOneSchema.js
@@ -659,6 +659,7 @@ module.exports = {
                 },
               },
             },
+            'additionalProperties': false,
           },
           'attachments\\.\\d+\\.name$': {
             'type': 'string',

--- a/tests/httpInterface.patchBulk.test.js
+++ b/tests/httpInterface.patchBulk.test.js
@@ -472,6 +472,61 @@ tap.test('HTTP PATCH /bulk', async t => {
       t.end()
     })
 
+    t.test('$set - with nested additional property', async t => {
+      const [DOC_TEST] = fixtures
+
+      const UPDATE_COMMAND = {
+        $set: {
+          'metadata.somethingNumber': VALUE_AS_STRING,
+          'metadata.somethingArrayObject.0.arrayItemObjectChildNumber': VALUE_AS_STRING,
+          'metadata.somethingArrayObject.1.arrayItemObjectChildNumber': VALUE_AS_STRING,
+          'metadata.somethingArrayObject.1.additionalProp': VALUE_AS_STRING,
+          'metadata.somethingArrayOfNumbers.0': VALUE_AS_STRING,
+        },
+      }
+
+      await resetCollection()
+
+      const response = await fastify.inject({
+        method: 'PATCH',
+        url: `${prefix}/bulk`,
+        payload: [
+          {
+            filter: {
+              _id: DOC_TEST._id,
+            },
+            update: UPDATE_COMMAND,
+          },
+        ],
+      })
+
+      t.test('should update one document', t => {
+        t.equal(JSON.parse(response.payload), 1)
+        t.end()
+      })
+
+      t.test('should update the document', async t => {
+        const docOnDb = await collection.findOne({ _id: DOC_TEST._id })
+        t.strictSame(docOnDb.metadata, {
+          somethingNumber: VALUE_AS_NUMBER,
+          somethingString: 'the-saved-string',
+          somethingArrayObject: [
+            {
+              arrayItemObjectChildNumber: VALUE_AS_NUMBER,
+            },
+            {
+              arrayItemObjectChildNumber: VALUE_AS_NUMBER,
+              additionalProp: VALUE_AS_STRING,
+            },
+          ],
+          somethingArrayOfNumbers: [VALUE_AS_NUMBER],
+        })
+        t.end()
+      })
+
+      t.end()
+    })
+
     t.test('$set - with replace operator', async t => {
       const OLD_VALUE = 2
 
@@ -632,7 +687,7 @@ tap.test('HTTP PATCH /bulk', async t => {
       t.end()
     })
 
-    t.test('$addToSet with array of object and nested additional property', async t => {
+    t.test('$addToSet - with array of object and nested additional property', async t => {
       const DOC_TEST = {
         ...fixtures[0],
         metadata: {
@@ -757,7 +812,7 @@ tap.test('HTTP PATCH /bulk', async t => {
       t.end()
     })
 
-    t.test('$pull with array of object and nested additional property', async t => {
+    t.test('$pull - with array of object and nested additional property', async t => {
       const DOC_TEST = {
         ...fixtures[0],
         tags: ['tag1', 'tag2', 'tag3'],


### PR DESCRIPTION
## Pull Request Type

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

Before this PR, $addToSet and $pull were not working with nested objects with `additionalProperties: true` if specifying an additional Property

## PR Checklist

- [X] The commit message follows our guidelines included in the [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-submit-a-pr)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


## Other information

Related to issue #89 