### PR TITLE
fix: updated endpoint tag format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - $text search query now working on aggregation
 - [#158](https://github.com/mia-platform/community/discussions/158) fixed wrong validation on nested objects.
+- endpoint tag format has been updated to correctly display paths with underscores
 
 ## 6.7.0 - 2023-06-19
 

--- a/lib/JSONSchemaGenerator.js
+++ b/lib/JSONSchemaGenerator.js
@@ -1549,8 +1549,7 @@ function getInheritedType(jsonSchema) {
 
 function formatEndpointTag(endpointBasePath) {
   return endpointBasePath
-    .replace(/\//g, '')
-    .replace(/\W|_/g, ' ')
-    .replace(/ (\w)/g, found => ` ${found[1].toUpperCase()}`)
-    .replace(/^(\w)/g, found => found[0].toUpperCase())
+    .replace(/^\//g, '')
+    .replace(/\//g, ' ')
+    .replace(/-/g, ' ')
 }

--- a/tests/expectedSchemas/booksBulkSchema.js
+++ b/tests/expectedSchemas/booksBulkSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Insert new items in the books collection.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksChangeStateManySchema.js
+++ b/tests/expectedSchemas/booksChangeStateManySchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Change state of multiple items of books.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksChangeStateSchema.js
+++ b/tests/expectedSchemas/booksChangeStateSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Change state of an item of books collection.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksCountSchema.js
+++ b/tests/expectedSchemas/booksCountSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Returns the number of items in the books collection.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksDeleteListSchema.js
+++ b/tests/expectedSchemas/booksDeleteListSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Delete multiple items from the books collection.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksDeleteSchema.js
+++ b/tests/expectedSchemas/booksDeleteSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Delete an item with specific ID from the books collection.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksExportSchema.js
+++ b/tests/expectedSchemas/booksExportSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Export the books collection',
   'description': 'The exported documents are sent as newline separated JSON objects to facilitate large dataset streaming and parsing',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksGetItemSchema.js
+++ b/tests/expectedSchemas/booksGetItemSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Returns the item with specific ID from the books collection.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksGetListLookupSchema.js
+++ b/tests/expectedSchemas/booksGetListLookupSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Returns a list of documents in books',
   'description': 'Results can be filtered specifying the following parameters:',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksGetListSchema.js
+++ b/tests/expectedSchemas/booksGetListSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Returns a list of documents in books',
   'description': 'Results can be filtered specifying the following parameters:',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksNewBulkSchema.js
+++ b/tests/expectedSchemas/booksNewBulkSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Insert new items in the books collection.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksNewChangeStateManySchema.js
+++ b/tests/expectedSchemas/booksNewChangeStateManySchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Change state of multiple items of books.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksNewChangeStateSchema.js
+++ b/tests/expectedSchemas/booksNewChangeStateSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Change state of an item of books collection.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksNewCountSchema.js
+++ b/tests/expectedSchemas/booksNewCountSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Returns the number of items in the books collection.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksNewDeleteListSchema.js
+++ b/tests/expectedSchemas/booksNewDeleteListSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Delete multiple items from the books collection.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksNewDeleteSchema.js
+++ b/tests/expectedSchemas/booksNewDeleteSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Delete an item with specific ID from the books collection.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksNewExportSchema.js
+++ b/tests/expectedSchemas/booksNewExportSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Export the books collection',
   'description': 'The exported documents are sent as newline separated JSON objects to facilitate large dataset streaming and parsing',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksNewGetItemSchema.js
+++ b/tests/expectedSchemas/booksNewGetItemSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Returns the item with specific ID from the books collection.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksNewGetListLookupSchema.js
+++ b/tests/expectedSchemas/booksNewGetListLookupSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Returns a list of documents in books',
   'description': 'Results can be filtered specifying the following parameters:',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksNewGetListSchema.js
+++ b/tests/expectedSchemas/booksNewGetListSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Returns a list of documents in books',
   'description': 'Results can be filtered specifying the following parameters:',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksNewPatchBulkSchema.js
+++ b/tests/expectedSchemas/booksNewPatchBulkSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update multiple items of books, each one with its own modifications',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksNewPatchManySchema.js
+++ b/tests/expectedSchemas/booksNewPatchManySchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update the items of the books collection that match the query.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksNewPatchSchema.js
+++ b/tests/expectedSchemas/booksNewPatchSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update the item with specific ID in the books collection.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksNewPostSchema.js
+++ b/tests/expectedSchemas/booksNewPostSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Add a new item to the books collection.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksNewUpsertOneSchema.js
+++ b/tests/expectedSchemas/booksNewUpsertOneSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update an item in the books collection. If the item is not in the collection, it will be inserted.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksPatchBulkSchema.js
+++ b/tests/expectedSchemas/booksPatchBulkSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update multiple items of books, each one with its own modifications',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksPatchManySchema.js
+++ b/tests/expectedSchemas/booksPatchManySchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update the items of the books collection that match the query.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksPatchSchema.js
+++ b/tests/expectedSchemas/booksPatchSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update the item with specific ID in the books collection.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksPostSchema.js
+++ b/tests/expectedSchemas/booksPostSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Add a new item to the books collection.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/booksUpsertOneSchema.js
+++ b/tests/expectedSchemas/booksUpsertOneSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update an item in the books collection. If the item is not in the collection, it will be inserted.',
   'tags': [
-    'Books Endpoint',
+    'books endpoint',
     'example',
     'tags',
   ],

--- a/tests/expectedSchemas/carsBulkSchema.js
+++ b/tests/expectedSchemas/carsBulkSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Insert new items in the cars collection.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'body': {
     'operationId': 'cars__MIA__postBulk__MIA__body',

--- a/tests/expectedSchemas/carsChangeStateManySchema.js
+++ b/tests/expectedSchemas/carsChangeStateManySchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Change state of multiple items of cars.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'body': {
     'operationId': 'cars__MIA__changeStateMany__MIA__body',

--- a/tests/expectedSchemas/carsChangeStateSchema.js
+++ b/tests/expectedSchemas/carsChangeStateSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Change state of an item of cars collection.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'params': {
     'operationId': 'cars__MIA__changeState__MIA__params',

--- a/tests/expectedSchemas/carsCountSchema.js
+++ b/tests/expectedSchemas/carsCountSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Returns the number of items in the cars collection.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'querystring': {
     'operationId': 'cars__MIA__count__MIA__querystring',

--- a/tests/expectedSchemas/carsDeleteListSchema.js
+++ b/tests/expectedSchemas/carsDeleteListSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Delete multiple items from the cars collection.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'querystring': {
     'operationId': 'cars__MIA__deleteList__MIA__querystring',

--- a/tests/expectedSchemas/carsDeleteSchema.js
+++ b/tests/expectedSchemas/carsDeleteSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Delete an item with specific ID from the cars collection.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'params': {
     'type': 'object',

--- a/tests/expectedSchemas/carsExportSchema.js
+++ b/tests/expectedSchemas/carsExportSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Export the cars collection',
   'description': 'The exported documents are sent as newline separated JSON objects to facilitate large dataset streaming and parsing',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'querystring': {
     'operationId': 'cars__MIA__export__MIA__querystring',

--- a/tests/expectedSchemas/carsGetItemSchema.js
+++ b/tests/expectedSchemas/carsGetItemSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Returns the item with specific ID from the cars collection.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'params': {
     'type': 'object',

--- a/tests/expectedSchemas/carsGetListLookupSchema.js
+++ b/tests/expectedSchemas/carsGetListLookupSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Returns a list of documents in cars',
   'description': 'Results can be filtered specifying the following parameters:',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'querystring': {
     'operationId': 'cars__MIA__getListLookup__MIA__querystring',

--- a/tests/expectedSchemas/carsGetListSchema.js
+++ b/tests/expectedSchemas/carsGetListSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Returns a list of documents in cars',
   'description': 'Results can be filtered specifying the following parameters:',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'querystring': {
     'operationId': 'cars__MIA__getList__MIA__querystring',

--- a/tests/expectedSchemas/carsNewBulkSchema.js
+++ b/tests/expectedSchemas/carsNewBulkSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Insert new items in the cars collection.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'body': {
     'operationId': 'cars__MIA__postBulk__MIA__body',

--- a/tests/expectedSchemas/carsNewChangeStateManySchema.js
+++ b/tests/expectedSchemas/carsNewChangeStateManySchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Change state of multiple items of cars.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'body': {
     'operationId': 'cars__MIA__changeStateMany__MIA__body',

--- a/tests/expectedSchemas/carsNewChangeStateSchema.js
+++ b/tests/expectedSchemas/carsNewChangeStateSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Change state of an item of cars collection.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'params': {
     'operationId': 'cars__MIA__changeState__MIA__params',

--- a/tests/expectedSchemas/carsNewCountSchema.js
+++ b/tests/expectedSchemas/carsNewCountSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Returns the number of items in the cars collection.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'querystring': {
     'operationId': 'cars__MIA__count__MIA__querystring',

--- a/tests/expectedSchemas/carsNewDeleteListSchema.js
+++ b/tests/expectedSchemas/carsNewDeleteListSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Delete multiple items from the cars collection.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'querystring': {
     'operationId': 'cars__MIA__deleteList__MIA__querystring',

--- a/tests/expectedSchemas/carsNewDeleteSchema.js
+++ b/tests/expectedSchemas/carsNewDeleteSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Delete an item with specific ID from the cars collection.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'params': {
     'type': 'object',

--- a/tests/expectedSchemas/carsNewExportSchema.js
+++ b/tests/expectedSchemas/carsNewExportSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Export the cars collection',
   'description': 'The exported documents are sent as newline separated JSON objects to facilitate large dataset streaming and parsing',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'querystring': {
     'operationId': 'cars__MIA__export__MIA__querystring',

--- a/tests/expectedSchemas/carsNewGetItemSchema.js
+++ b/tests/expectedSchemas/carsNewGetItemSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Returns the item with specific ID from the cars collection.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'params': {
     'type': 'object',

--- a/tests/expectedSchemas/carsNewGetListLookupSchema.js
+++ b/tests/expectedSchemas/carsNewGetListLookupSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Returns a list of documents in cars',
   'description': 'Results can be filtered specifying the following parameters:',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'querystring': {
     'operationId': 'cars__MIA__getListLookup__MIA__querystring',

--- a/tests/expectedSchemas/carsNewGetListSchema.js
+++ b/tests/expectedSchemas/carsNewGetListSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Returns a list of documents in cars',
   'description': 'Results can be filtered specifying the following parameters:',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'querystring': {
     'operationId': 'cars__MIA__getList__MIA__querystring',

--- a/tests/expectedSchemas/carsNewPatchBulkSchema.js
+++ b/tests/expectedSchemas/carsNewPatchBulkSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update multiple items of cars, each one with its own modifications',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'body': {
     'operationId': 'cars__MIA__patchBulk__MIA__body',

--- a/tests/expectedSchemas/carsNewPatchManySchema.js
+++ b/tests/expectedSchemas/carsNewPatchManySchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update the items of the cars collection that match the query.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'querystring': {
     'operationId': 'cars__MIA__patchMany__MIA__querystring',

--- a/tests/expectedSchemas/carsNewPatchSchema.js
+++ b/tests/expectedSchemas/carsNewPatchSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update the item with specific ID in the cars collection.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'params': {
     'properties': {

--- a/tests/expectedSchemas/carsNewPostSchema.js
+++ b/tests/expectedSchemas/carsNewPostSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Add a new item to the cars collection.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'body': {
     'operationId': 'cars__MIA__postItem__MIA__body',

--- a/tests/expectedSchemas/carsNewUpsertOneSchema.js
+++ b/tests/expectedSchemas/carsNewUpsertOneSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update an item in the cars collection. If the item is not in the collection, it will be inserted.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'querystring': {
     'operationId': 'cars__MIA__upsertOne__MIA__querystring',

--- a/tests/expectedSchemas/carsPatchBulkSchema.js
+++ b/tests/expectedSchemas/carsPatchBulkSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update multiple items of cars, each one with its own modifications',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'body': {
     'operationId': 'cars__MIA__patchBulk__MIA__body',

--- a/tests/expectedSchemas/carsPatchManySchema.js
+++ b/tests/expectedSchemas/carsPatchManySchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update the items of the cars collection that match the query.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'querystring': {
     'operationId': 'cars__MIA__patchMany__MIA__querystring',

--- a/tests/expectedSchemas/carsPatchSchema.js
+++ b/tests/expectedSchemas/carsPatchSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update the item with specific ID in the cars collection.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'params': {
     'properties': {

--- a/tests/expectedSchemas/carsPostSchema.js
+++ b/tests/expectedSchemas/carsPostSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Add a new item to the cars collection.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'body': {
     'operationId': 'cars__MIA__postItem__MIA__body',

--- a/tests/expectedSchemas/carsUpsertOneSchema.js
+++ b/tests/expectedSchemas/carsUpsertOneSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update an item in the cars collection. If the item is not in the collection, it will be inserted.',
   'tags': [
-    'Cars Endpoint',
+    'cars endpoint',
   ],
   'querystring': {
     'operationId': 'cars__MIA__upsertOne__MIA__querystring',

--- a/tests/expectedSchemas/stationsBulkSchema.js
+++ b/tests/expectedSchemas/stationsBulkSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Insert new items in the stations collection.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'body': {
     'operationId': 'stations__MIA__postBulk__MIA__body',

--- a/tests/expectedSchemas/stationsChangeStateManySchema.js
+++ b/tests/expectedSchemas/stationsChangeStateManySchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Change state of multiple items of stations.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'body': {
     'operationId': 'stations__MIA__changeStateMany__MIA__body',

--- a/tests/expectedSchemas/stationsChangeStateSchema.js
+++ b/tests/expectedSchemas/stationsChangeStateSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Change state of an item of stations collection.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'params': {
     'operationId': 'stations__MIA__changeState__MIA__params',

--- a/tests/expectedSchemas/stationsCountSchema.js
+++ b/tests/expectedSchemas/stationsCountSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Returns the number of items in the stations collection.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'querystring': {
     'operationId': 'stations__MIA__count__MIA__querystring',

--- a/tests/expectedSchemas/stationsDeleteListSchema.js
+++ b/tests/expectedSchemas/stationsDeleteListSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Delete multiple items from the stations collection.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'querystring': {
     'operationId': 'stations__MIA__deleteList__MIA__querystring',

--- a/tests/expectedSchemas/stationsDeleteSchema.js
+++ b/tests/expectedSchemas/stationsDeleteSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Delete an item with specific ID from the stations collection.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'params': {
     'type': 'object',

--- a/tests/expectedSchemas/stationsExportSchema.js
+++ b/tests/expectedSchemas/stationsExportSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Export the stations collection',
   'description': 'The exported documents are sent as newline separated JSON objects to facilitate large dataset streaming and parsing',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'querystring': {
     'operationId': 'stations__MIA__export__MIA__querystring',

--- a/tests/expectedSchemas/stationsGetItemSchema.js
+++ b/tests/expectedSchemas/stationsGetItemSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Returns the item with specific ID from the stations collection.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'params': {
     'type': 'object',

--- a/tests/expectedSchemas/stationsGetListLookupSchema.js
+++ b/tests/expectedSchemas/stationsGetListLookupSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Returns a list of documents in stations',
   'description': 'Results can be filtered specifying the following parameters:',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'querystring': {
     'operationId': 'stations__MIA__getListLookup__MIA__querystring',

--- a/tests/expectedSchemas/stationsGetListSchema.js
+++ b/tests/expectedSchemas/stationsGetListSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Returns a list of documents in stations',
   'description': 'Results can be filtered specifying the following parameters:',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'querystring': {
     'operationId': 'stations__MIA__getList__MIA__querystring',

--- a/tests/expectedSchemas/stationsNewBulkSchema.js
+++ b/tests/expectedSchemas/stationsNewBulkSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Insert new items in the stations collection.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'body': {
     'operationId': 'stations__MIA__postBulk__MIA__body',

--- a/tests/expectedSchemas/stationsNewChangeStateManySchema.js
+++ b/tests/expectedSchemas/stationsNewChangeStateManySchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Change state of multiple items of stations.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'body': {
     'operationId': 'stations__MIA__changeStateMany__MIA__body',

--- a/tests/expectedSchemas/stationsNewChangeStateSchema.js
+++ b/tests/expectedSchemas/stationsNewChangeStateSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Change state of an item of stations collection.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'params': {
     'operationId': 'stations__MIA__changeState__MIA__params',

--- a/tests/expectedSchemas/stationsNewCountSchema.js
+++ b/tests/expectedSchemas/stationsNewCountSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Returns the number of items in the stations collection.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'querystring': {
     'operationId': 'stations__MIA__count__MIA__querystring',

--- a/tests/expectedSchemas/stationsNewDeleteListSchema.js
+++ b/tests/expectedSchemas/stationsNewDeleteListSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Delete multiple items from the stations collection.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'querystring': {
     'operationId': 'stations__MIA__deleteList__MIA__querystring',

--- a/tests/expectedSchemas/stationsNewDeleteSchema.js
+++ b/tests/expectedSchemas/stationsNewDeleteSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Delete an item with specific ID from the stations collection.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'params': {
     'type': 'object',

--- a/tests/expectedSchemas/stationsNewExportSchema.js
+++ b/tests/expectedSchemas/stationsNewExportSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Export the stations collection',
   'description': 'The exported documents are sent as newline separated JSON objects to facilitate large dataset streaming and parsing',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'querystring': {
     'operationId': 'stations__MIA__export__MIA__querystring',

--- a/tests/expectedSchemas/stationsNewGetItemSchema.js
+++ b/tests/expectedSchemas/stationsNewGetItemSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Returns the item with specific ID from the stations collection.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'params': {
     'type': 'object',

--- a/tests/expectedSchemas/stationsNewGetListLookupSchema.js
+++ b/tests/expectedSchemas/stationsNewGetListLookupSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Returns a list of documents in stations',
   'description': 'Results can be filtered specifying the following parameters:',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'querystring': {
     'operationId': 'stations__MIA__getListLookup__MIA__querystring',

--- a/tests/expectedSchemas/stationsNewGetListSchema.js
+++ b/tests/expectedSchemas/stationsNewGetListSchema.js
@@ -20,7 +20,7 @@ module.exports = {
   'summary': 'Returns a list of documents in stations',
   'description': 'Results can be filtered specifying the following parameters:',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'querystring': {
     'operationId': 'stations__MIA__getList__MIA__querystring',

--- a/tests/expectedSchemas/stationsNewPatchBulkSchema.js
+++ b/tests/expectedSchemas/stationsNewPatchBulkSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update multiple items of stations, each one with its own modifications',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'body': {
     'operationId': 'stations__MIA__patchBulk__MIA__body',

--- a/tests/expectedSchemas/stationsNewPatchManySchema.js
+++ b/tests/expectedSchemas/stationsNewPatchManySchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update the items of the stations collection that match the query.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'querystring': {
     'operationId': 'stations__MIA__patchMany__MIA__querystring',

--- a/tests/expectedSchemas/stationsNewPatchSchema.js
+++ b/tests/expectedSchemas/stationsNewPatchSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update the item with specific ID in the stations collection.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'params': {
     'properties': {

--- a/tests/expectedSchemas/stationsNewPostSchema.js
+++ b/tests/expectedSchemas/stationsNewPostSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Add a new item to the stations collection.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'body': {
     'operationId': 'stations__MIA__postItem__MIA__body',

--- a/tests/expectedSchemas/stationsNewUpsertOneSchema.js
+++ b/tests/expectedSchemas/stationsNewUpsertOneSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update an item in the stations collection. If the item is not in the collection, it will be inserted.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'querystring': {
     'operationId': 'stations__MIA__upsertOne__MIA__querystring',

--- a/tests/expectedSchemas/stationsPatchBulkSchema.js
+++ b/tests/expectedSchemas/stationsPatchBulkSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update multiple items of stations, each one with its own modifications',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'body': {
     'operationId': 'stations__MIA__patchBulk__MIA__body',

--- a/tests/expectedSchemas/stationsPatchManySchema.js
+++ b/tests/expectedSchemas/stationsPatchManySchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update the items of the stations collection that match the query.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'querystring': {
     'operationId': 'stations__MIA__patchMany__MIA__querystring',

--- a/tests/expectedSchemas/stationsPatchSchema.js
+++ b/tests/expectedSchemas/stationsPatchSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update the item with specific ID in the stations collection.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'params': {
     'properties': {

--- a/tests/expectedSchemas/stationsPostSchema.js
+++ b/tests/expectedSchemas/stationsPostSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Add a new item to the stations collection.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'body': {
     'operationId': 'stations__MIA__postItem__MIA__body',

--- a/tests/expectedSchemas/stationsUpsertOneSchema.js
+++ b/tests/expectedSchemas/stationsUpsertOneSchema.js
@@ -19,7 +19,7 @@
 module.exports = {
   'summary': 'Update an item in the stations collection. If the item is not in the collection, it will be inserted.',
   'tags': [
-    'Stations Endpoint',
+    'stations endpoint',
   ],
   'querystring': {
     'operationId': 'stations__MIA__upsertOne__MIA__querystring',


### PR DESCRIPTION
This PR has the goal of updating the format of endpoint tags, fixing a bug that wrongly removed underscores in endpoint names.

Tests have been updated accordingly.

e.g.:
Base path: `/books/pr_books/`
Before fix endpoint tag: `Books Pr Books`
After fix endpoint tag: `books pr_books`