### PR TITLE
feat: not allowed state transitions returns error 400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ values and select the one with the highest weight
 
 ### Changed
 
-- [mia-platform/[#53](https://github.com/mia-platform/crud-service/issues/53) request to transition to a not allowed state returns 400 instead of 400
+- [mia-platform/[#53](https://github.com/mia-platform/crud-service/issues/53) request to transition to a not allowed state returns 400 instead of 404.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ values and select the one with the highest weight
 
 - [mia-platform/#256](https://github.com/mia-platform/community/discussions/256) configurable collection tags.
 
+### Changed
+
+- [mia-platform/[#53](https://github.com/mia-platform/crud-service/issues/53) request to transition to a not allowed state returns 400 instead of 400
+
 ### Fixed
 
 - $text search query now working on aggregation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### BREAKING CHANGES
 
-- [#140](https://github.com/mia-platform/crud-service/pull/140) changed response code on unique constraint violation wrt [mia-platform/#175](https://github.com/mia-platform/community/discussions/175)
 - remove support to MongoDB v4.2
+- [#140](https://github.com/mia-platform/crud-service/pull/140) changed response code on unique constraint violation with respect to [mia-platform/#175](https://github.com/mia-platform/community/discussions/175)
+- [#53](https://github.com/mia-platform/crud-service/issues/53) request to transition to a disallowed state now returns HTTP error 400 instead of 404
 
 ### Changed
 
@@ -57,10 +58,6 @@ values and select the one with the highest weight
 ### Added
 
 - [mia-platform/#256](https://github.com/mia-platform/community/discussions/256) configurable collection tags.
-
-### Changed
-
-- [mia-platform/[#53](https://github.com/mia-platform/crud-service/issues/53) request to transition to a not allowed state returns 400 instead of 404.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -253,13 +253,16 @@ When working with collections via CRUD Service, some fields will be automaticall
 
 #### Document State management
 
-We've just explained the difference between the four possible states of a document. This property can be set directly during an _insert_, and can be changed via REST API calls only in case of the following transformations:
+We've just explained the difference between the four possible states of a document. This property can be set directly during an _insert_, and can be changed via REST API calls only in the case of the following transformations:
 - a document in `PUBLIC` can be moved to `DRAFT` or `TRASH`; 
 - a document in `DRAFT` can be moved to `PUBLIC` or `TRASH`; 
 - a document in `TRASH` can be moved to `DRAFT` or `DELETED`; 
-- a document in `DELETED` can be moved to only to `TRASH`; 
+- a document in `DELETED` can be moved only to `TRASH`;
+Any request to transition to a not allowed state will be refused and a _400 Bad Request_ will be returned.
 
-Operations of hard delete are supported, although the permissions over this type of operations is defined via ACL.
+**NOTE**: Any request to transition to update the state to the current one (e.g. from `PUBLIC` to `PUBLIC`) will be executed successfully, leaving the `__STATE__` as it is, but updating the _updaterId_ and the _updatedAt_ metadata fields.
+
+Operations of hard delete are supported, although the permissions over this type of operation are defined via ACL.
   
 ### Crud service
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ We've just explained the difference between the four possible states of a docume
 - a document in `DELETED` can be moved only to `TRASH`;
 Any request to transition to a not allowed state will be refused and a _400 Bad Request_ will be returned.
 
-**NOTE**: Any request to transition to update the state to the current one (e.g. from `PUBLIC` to `PUBLIC`) will be executed successfully, leaving the `__STATE__` as it is, but updating the _updaterId_ and the _updatedAt_ metadata fields.
+**NOTE**: If you request to update the state to its current value (e.g., from `PUBLIC` to `PUBLIC`), it will be successful. The `__STATE__` will remain the same, but the _updaterId_ and _updatedAt_ metadata fields will be updated.
 
 Operations of hard delete are supported, although the permissions over this type of operation are defined via ACL.
   

--- a/lib/CrudService.js
+++ b/lib/CrudService.js
@@ -449,7 +449,7 @@ class CrudService {
   async changeStateById(context, id, stateTo, query) {
     context.log.debug({ query, stateTo }, 'changeStateById operation requested')
 
-    assert.ok(Object.keys(STATES_FINITE_STATE_MACHINE).includes(stateTo), `Invalid current \`stateTo\` parameter: ${stateTo}`)
+    assert.ok(stateTo in STATES_FINITE_STATE_MACHINE, `Invalid current \`stateTo\` parameter: ${stateTo}`)
     const isQueryValid = query && Object.keys(query).length > 0
 
     const searchQuery = isQueryValid

--- a/lib/CrudService.js
+++ b/lib/CrudService.js
@@ -466,7 +466,10 @@ class CrudService {
     const currentState = documentToUpdate[__STATE__]
     const allowedStates = ALLOWED_STATES_MAP[currentState]
 
-    if (!allowedStates.includes(stateTo)) {
+    // this check on current state existence of allows this API
+    // to assign a __STATE__ to documents that does not have the field
+    // (no current state means that any transition is valid)
+    if (currentState && !allowedStates.includes(stateTo)) {
       context.log.debug({ _id: documentToUpdate._id, from: currentState, to: stateTo }, 'transition from states not allowed')
       const error = new Error(`transition from ${currentState} to ${stateTo} not allowed.`)
       error.statusCode = 400
@@ -480,7 +483,12 @@ class CrudService {
         [UPDATEDAT]: context.now,
       },
     }
-    const { modifiedCount } = await this._mongoCollection.updateOne(searchQuery, commands)
+    // adding current document state to the search filter of the operation ensure
+    // that the state has not changed since the find operation executed above
+    const { modifiedCount } = await this._mongoCollection.updateOne(
+      { $and: [searchQuery, { __STATE__: currentState }] },
+      commands
+    )
 
     context.log.debug({ modifiedCount }, 'changeStateById operation executed')
     return modifiedCount

--- a/lib/CrudService.js
+++ b/lib/CrudService.js
@@ -64,13 +64,24 @@ const STANDARD_FIELDS = [
 
 /**
  * List of states available for a document managed by the CRUD Service
- * and the possible states it could move to based on requested operations
+ * and the possible states it can start from, based on requested operations
  */
 const STATES_FINITE_STATE_MACHINE = {
   [PUBLIC]: [DRAFT],
   [DRAFT]: [PUBLIC, TRASH],
   [TRASH]: [PUBLIC, DRAFT, DELETED],
   [DELETED]: [TRASH],
+}
+
+/**
+ * List of status available for a document managed by the CRUD Service
+ * and the possible states it can move to, based on the requested operations
+ */
+const ALLOWED_STATES_MAP = {
+  [PUBLIC]: [DRAFT, PUBLIC, TRASH],
+  [DRAFT]: [DRAFT, PUBLIC, TRASH],
+  [TRASH]: [DELETED, DRAFT, TRASH],
+  [DELETED]: [DELETED, TRASH],
 }
 
 const NO_DOCUMENT_FOUND = '<no document found>'
@@ -437,14 +448,30 @@ class CrudService {
 
   async changeStateById(context, id, stateTo, query) {
     context.log.debug({ query, stateTo }, 'changeStateById operation requested')
-    const currentState = STATES_FINITE_STATE_MACHINE[stateTo]
-    assert.ok(currentState, `Invalid current \`stateTo\` parameter: ${stateTo}`)
 
+    assert.ok(Object.keys(STATES_FINITE_STATE_MACHINE).includes(stateTo), `Invalid current \`stateTo\` parameter: ${stateTo}`)
     const isQueryValid = query && Object.keys(query).length > 0
 
     const searchQuery = isQueryValid
       ? { $and: [query, { _id: id }] }
       : { _id: id }
+
+
+    const documentToUpdate = await this._mongoCollection.findOne(searchQuery)
+
+    if (!documentToUpdate) {
+      return null
+    }
+
+    const currentState = documentToUpdate[__STATE__]
+    const allowedStates = ALLOWED_STATES_MAP[currentState]
+
+    if (!allowedStates.includes(stateTo)) {
+      context.log.debug({ _id: documentToUpdate._id, from: currentState, to: stateTo }, 'transition from states not allowed')
+      const error = new Error(`transition from ${currentState} to ${stateTo} not allowed.`)
+      error.statusCode = 400
+      throw error
+    }
 
     const commands = {
       $set: {
@@ -453,21 +480,10 @@ class CrudService {
         [UPDATEDAT]: context.now,
       },
     }
+    const { modifiedCount } = await this._mongoCollection.updateOne(searchQuery, commands)
 
-    const documentToUpdate = await this._mongoCollection.findOne(searchQuery)
-
-    if (!documentToUpdate) {
-      return null
-    }
-
-    if (!currentState.includes(documentToUpdate[__STATE__])) {
-      throw new Error(`transition from ${documentToUpdate[__STATE__]} to ${stateTo} not allowed.`)
-    }
-
-    const writeOpResult = await this._mongoCollection.updateOne(searchQuery, commands)
-    console.log({ updateResult: writeOpResult })
-    context.log.debug({ docId: writeOpResult.value?._id || NO_DOCUMENT_FOUND }, 'changeStateById operation executed')
-    return writeOpResult
+    context.log.debug({ modifiedCount }, 'changeStateById operation executed')
+    return modifiedCount
   }
 
   async changeStateMany(context, filterUpdateCommands) {

--- a/lib/CrudService.js
+++ b/lib/CrudService.js
@@ -438,14 +438,13 @@ class CrudService {
   async changeStateById(context, id, stateTo, query) {
     context.log.debug({ query, stateTo }, 'changeStateById operation requested')
     const currentState = STATES_FINITE_STATE_MACHINE[stateTo]
-    assert(currentState, `Invalid current \`stateTo\` parameter: ${stateTo}`)
+    assert.ok(currentState, `Invalid current \`stateTo\` parameter: ${stateTo}`)
 
-    const stateQuery = { [__STATE__]: { $in: currentState } }
     const isQueryValid = query && Object.keys(query).length > 0
 
     const searchQuery = isQueryValid
-      ? { $and: [query, { _id: id }, stateQuery] }
-      : { $and: [{ _id: id }, stateQuery] }
+      ? { $and: [query, { _id: id }] }
+      : { _id: id }
 
     const commands = {
       $set: {
@@ -455,14 +454,20 @@ class CrudService {
       },
     }
 
-    const writeOpResult = await this._mongoCollection.findOneAndUpdate(
-      searchQuery,
-      commands,
-      { returnDocument: 'after' }
-    )
+    const documentToUpdate = await this._mongoCollection.findOne(searchQuery)
 
+    if (!documentToUpdate) {
+      return null
+    }
+
+    if (!currentState.includes(documentToUpdate[__STATE__])) {
+      throw new Error(`transition from ${documentToUpdate[__STATE__]} to ${stateTo} not allowed.`)
+    }
+
+    const writeOpResult = await this._mongoCollection.updateOne(searchQuery, commands)
+    console.log({ updateResult: writeOpResult })
     context.log.debug({ docId: writeOpResult.value?._id || NO_DOCUMENT_FOUND }, 'changeStateById operation executed')
-    return writeOpResult.value
+    return writeOpResult
   }
 
   async changeStateMany(context, filterUpdateCommands) {

--- a/lib/httpInterface.js
+++ b/lib/httpInterface.js
@@ -900,7 +900,11 @@ async function handleChangeStateById(request, reply) {
 
     reply.code(204)
   } catch (error) {
-    return reply.getHttpError(BAD_REQUEST_ERROR_STATUS_CODE, error.message)
+    if (error.statusCode) {
+      return reply.getHttpError(error.statusCode, error.message)
+    }
+
+    throw error
   }
 }
 

--- a/lib/httpInterface.js
+++ b/lib/httpInterface.js
@@ -892,13 +892,16 @@ async function handleChangeStateById(request, reply) {
   const docId = request.params.id
   const _id = this.castCollectionId(docId)
 
-  const doc = await this.crudService.changeStateById(crudContext, _id, body.stateTo, mongoQuery)
+  try {
+    const doc = await this.crudService.changeStateById(crudContext, _id, body.stateTo, mongoQuery)
+    if (!doc) {
+      return reply.notFound()
+    }
 
-  if (!doc) {
-    return reply.notFound()
+    reply.code(204)
+  } catch (error) {
+    return reply.getHttpError(BAD_REQUEST_ERROR_STATUS_CODE, error.message)
   }
-
-  reply.code(204)
 }
 
 async function handleChangeStateMany(request) {

--- a/tests/httpInterface.changeStateById.test.js
+++ b/tests/httpInterface.changeStateById.test.js
@@ -39,7 +39,7 @@ const NON_MATCHING_PRICE = DOC.price + 1
 const MATCHING_QUERY = { price: { $gt: MATCHING_PRICE } }
 const NON_MATCHING_QUERY = { price: { $gt: NON_MATCHING_PRICE } }
 
-const [STATION_DOC] = stationFixtures
+const [STATION_DOC, STATION_DOC_NO_STATE] = stationFixtures
 const STATION_ID = STATION_DOC._id.toString()
 
 tap.test('HTTP POST /<id>/state', async t => {
@@ -115,7 +115,6 @@ tap.test('HTTP POST /<id>/state', async t => {
     },
   ]
 
-  t.plan(tests.length)
   const { fastify, collection, resetCollection } = await setUpTest(t)
 
   tests.forEach(testConf => {
@@ -197,9 +196,16 @@ tap.test('HTTP POST /<id>/state with string id', async t => {
       id: STATION_DOC._id,
       found: true,
     },
+    {
+      name: 'with document missing __STATE__field',
+      url: `/${STATION_DOC_NO_STATE._id}/state`,
+      acl_rows: undefined,
+      stateTo: STATES.PUBLIC,
+      id: STATION_DOC_NO_STATE._id,
+      found: true,
+    },
   ]
 
-  t.plan(tests.length)
   const { fastify, collection, resetCollection } = await setUpTest(t, stationFixtures, 'stations')
 
   tests.forEach(testConf => {
@@ -337,7 +343,6 @@ tap.test('HTTP POST /<id>/state passing to a wrong state', async t => {
     },
   ]
 
-  t.plan(tests.length)
   const { fastify, collection, resetCollection } = await setUpTest(t, stationFixtures, 'stations')
 
   tests.forEach(testConf => {

--- a/tests/httpInterface.changeStateById.test.js
+++ b/tests/httpInterface.changeStateById.test.js
@@ -42,7 +42,7 @@ const NON_MATCHING_QUERY = { price: { $gt: NON_MATCHING_PRICE } }
 const [STATION_DOC] = stationFixtures
 const STATION_ID = STATION_DOC._id.toString()
 
-tap.skip('HTTP POST /<id>/state', async t => {
+tap.test('HTTP POST /<id>/state', async t => {
   const tests = [
     {
       name: 'without filter',
@@ -97,14 +97,6 @@ tap.skip('HTTP POST /<id>/state', async t => {
       url: `/${ID}/state`,
       acl_rows: [NON_MATCHING_QUERY],
       stateTo: STATES.DRAFT,
-      id: DOC._id,
-      found: false,
-    },
-    {
-      name: 'to wrong state',
-      url: `/${ID}/state`,
-      acl_rows: undefined,
-      stateTo: 'DELETED',
       id: DOC._id,
       found: false,
     },
@@ -187,7 +179,7 @@ tap.skip('HTTP POST /<id>/state', async t => {
   })
 })
 
-tap.skip('HTTP POST /<id>/state with string id', async t => {
+tap.test('HTTP POST /<id>/state with string id', async t => {
   const tests = [
     {
       name: 'without filter',
@@ -303,6 +295,11 @@ tap.test('HTTP POST /<id>/state passing to a wrong state', async t => {
       ...baseFields,
       [__STATE__]: STATES.DRAFT,
     },
+    {
+      _id: '002415b0-8d6d-427c-b654-9857183e57a9',
+      ...baseFields,
+      [__STATE__]: STATES.TRASH,
+    },
   ]
 
   const [DELETED_STATION_DOC, PUBLIC_STATION_DOC, DRAFT_STATION_DOC] = stationFixtures
@@ -321,7 +318,19 @@ tap.test('HTTP POST /<id>/state passing to a wrong state', async t => {
       id: DRAFT_STATION_DOC._id,
     },
     {
+      name: 'from TRASH to PUBLIC',
+      url: `/${DELETED_STATION_DOC._id.toString()}/state`,
+      stateTo: STATES.PUBLIC,
+      id: DELETED_STATION_DOC._id,
+    },
+    {
       name: 'from DELETED to PUBLIC',
+      url: `/${DELETED_STATION_DOC._id.toString()}/state`,
+      stateTo: STATES.PUBLIC,
+      id: DELETED_STATION_DOC._id,
+    },
+    {
+      name: 'from DELETED to DRAFT',
       url: `/${DELETED_STATION_DOC._id.toString()}/state`,
       stateTo: STATES.PUBLIC,
       id: DELETED_STATION_DOC._id,

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -389,6 +389,22 @@ const stationFixtures = [
     [UPDATEDAT]: updatedAtDate,
     [__STATE__]: STATES.PUBLIC,
   },
+  {
+    _id: '3bb78876-c8bb-4e02-bad5-440f220e9f73',
+    Cap: 20831,
+    CodiceMIR: 'S09001',
+    Comune: 'Seregno',
+    Direttrici: [
+      'D042',
+    ],
+    Indirizzo: 'Via Montello',
+    country: 'it',
+    [CREATEDAT]: createdAtDate,
+    [CREATORID]: creatorId,
+    [UPDATERID]: updaterId,
+    [UPDATEDAT]: updatedAtDate,
+    // Note: this document has been intentionally left without __STATE__ field
+  },
 ]
 
 async function clearCollectionAndInsertFixtures(collection, testFixtures = fixtures) {


### PR DESCRIPTION
<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

## Pull Request Type
<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

<!-- 
    Please include here a description of the Pull Request: what you are modifying, why you are proposing it, why is important..
    Feel free to link a relevant issue that might be affected by your updates.
-->

Solves #53 

The method `{id}/state` (POST) execute `__STATE__` updates in a different way, following the rules of the [document state management](https://github.com/mia-platform/crud-service#document-state-management).

Before:
- the crudService executes a findOneAndUpdate with the query parameters included and a `$in` operator based on the possible states the document can start from (like explained in the link above but in reverse) and returns one of the following;
  - if a document is found (and, therefore, updated), return `204 No Content`;
  - if a document is not found (no result with given query or non allowed `__STATE__` to start with): return `404 Not Found`;
  - any other error (Mongo connection, other shenanigans) are not handled, returning the exception as received;

Now:
- the crudService executes a findOne based on the _id_ (and the query parameters, if included);
  - if a document is not found (no result with given query or non allowed `__STATE__` to start with): return `404 Not Found`;
  - if a document is found, a check is performed to verify we can move to that `__STATE__`;
    - if not possible, returns a `400 Bad Request` with a message explaining the not allowed state transition;
    - if possible, an updateOne is executed returning `204 No Content` (or any other `500` in case of other problems);

Breaking changes:
- from now on, a non-allowed state transition returns `400` (and not anymore a `404`);
- requesting a state update **to the same state** (e.g. from `PUBLIC` to `PUBLIC`) updates the document anyway (`updatedAt` and `updaterId` properties are updated);

More:
- unit tests have been refactored a little (to separate different cases), and now includes more cases of non allowed transitions;

## PR Checklist

<!-- TODO: Include update for the CONTRIBUTING file up-to-date regarding information about the commit -->
- [X] The commit message follows our guidelines included in the [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-submit-a-pr)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Use this space to include more information about your pull request. If you don't need to add anything, feel free to remove this section. -->