### PR TITLE
fix(#224): create indexes limiting promises concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `MONGODB_MAX_IDLE_TIME_MS` env to control MongoDB `maxIdleTimeMs` connection option (default set to 0 for backward compatibility, meaning the opened connection remain opened indefinitely)
+- [#225](https://github.com/mia-platform/crud-service/pull/225): `MONGODB_MAX_IDLE_TIME_MS` env to control MongoDB `maxIdleTimeMs` connection option (default set to 0 for backward compatibility, meaning the opened connection remain opened indefinitely)
+
+### Fixed
+
+- [#227](https://github.com/mia-platform/crud-service/pull/227): create indexes limiting promises concurrency to prevent connection creation spikes at boot
 
 ## 6.9.3 - 2023-11-21
 

--- a/lib/loadModels.js
+++ b/lib/loadModels.js
@@ -16,7 +16,6 @@
 
 'use strict'
 
-/* eslint-disable no-await-in-loop */
 const Ajv = require('ajv')
 const ajvFormats = require('ajv-formats')
 const ajvKeywords = require('ajv-keywords')
@@ -47,7 +46,6 @@ const VIEW_TYPE = 'view'
 
 const limiter = plimit(5)
 
-// eslint-disable-next-line max-statements
 async function loadModels(fastify) {
   const { collections, views = [] } = fastify
   const mergedCollections = mergeViewsInCollections(collections, views)

--- a/lib/loadModels.js
+++ b/lib/loadModels.js
@@ -73,15 +73,15 @@ async function loadModels(fastify) {
 function collectionModelMapper(
   fastify,
   mergedCollections,
-  // The previous implementation of the mapper was with a closure function that
-  // applied a side-effect on these values. During the refactor to apply p-limit
-  // I've decided not to change the implementation, therefore I've wrapped the params to isolate them.
+  // The previous implementation of the mapper was with a closure function that applied a
+  // side-effect on these values. During the refactor to apply p-limit I've decided not to
+  // change the implementation, therefore I've wrapped the params to isolate them.
   { models, existingStringCollection, existingObjectIdCollection }
 ) {
   // eslint-disable-next-line max-statements
   return async(collectionDefinition) => {
-  // avoid validating the collection definition twice, since it would only
-  // match one of the two, depending on the existence of schema property
+    // avoid validating the collection definition twice, since it would only
+    // match one of the two, depending on the existence of schema property
     if (!collectionDefinition.schema) {
       if (!compatibilityValidate(collectionDefinition)) {
         fastify.log.error({ collection: collectionDefinition.name }, compatibilityValidate.errors)

--- a/lib/loadModels.js
+++ b/lib/loadModels.js
@@ -21,6 +21,7 @@ const Ajv = require('ajv')
 const ajvFormats = require('ajv-formats')
 const ajvKeywords = require('ajv-keywords')
 const lomit = require('lodash.omit')
+const plimit = require('p-limit')
 
 const mergeViewsInCollections = require('./mergeViewsInCollections')
 const { compatibilityModelJsonSchema, modelJsonSchema } = require('./model.jsonschema')
@@ -44,6 +45,8 @@ const validate = ajv.compile(modelJsonSchema)
 const PREFIX_OF_INDEX_NAMES_TO_PRESERVE = 'preserve_'
 const VIEW_TYPE = 'view'
 
+const limiter = plimit(5)
+
 // eslint-disable-next-line max-statements
 async function loadModels(fastify) {
   const { collections, views = [] } = fastify
@@ -51,14 +54,36 @@ async function loadModels(fastify) {
 
   fastify.log.trace({ collectionNames: mergedCollections.map(coll => coll.name) }, 'Registering CRUDs and Views')
 
+  // A side-effect from the collectionModelMapper updates the following data models.
   const models = {}
   const existingStringCollection = []
   const existingObjectIdCollection = []
 
+  const promises = mergedCollections.map(
+    (collectionDefinition) => limiter(() =>
+      collectionModelMapper(
+        fastify,
+        mergedCollections,
+        { models, existingStringCollection, existingObjectIdCollection }
+      )(collectionDefinition)
+    )
+  )
+  await Promise.all(promises)
+  fastify.decorate('models', models)
+}
+
+function collectionModelMapper(
+  fastify,
+  mergedCollections,
+  // The previous implementation of the mapper was with a closure function that
+  // applied a side-effect on these values. During the refactor to apply p-limit
+  // I've decided not to change the implementation, therefore I've wrapped the params to isolate them.
+  { models, existingStringCollection, existingObjectIdCollection }
+) {
   // eslint-disable-next-line max-statements
-  const promises = mergedCollections.map(async(collectionDefinition) => {
-    // avoid validating the collection definition twice, since it would only
-    // match one of the two, depending on the existence of schema property
+  return async(collectionDefinition) => {
+  // avoid validating the collection definition twice, since it would only
+  // match one of the two, depending on the existence of schema property
     if (!collectionDefinition.schema) {
       if (!compatibilityValidate(collectionDefinition)) {
         fastify.log.error({ collection: collectionDefinition.name }, compatibilityValidate.errors)
@@ -152,11 +177,7 @@ async function loadModels(fastify) {
     }
 
     return createIndexes(collection, indexes, PREFIX_OF_INDEX_NAMES_TO_PRESERVE)
-  })
-  while (promises.length) {
-    await Promise.all(promises.splice(0, 5))
   }
-  fastify.decorate('models', models)
 }
 
 function getCollectionNameFromEndpoint(endpointBasePath) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "lodash.unset": "^4.5.2",
         "mongodb-client-encryption": "^2.9.0",
         "ndjson": "^2.0.0",
+        "p-limit": "^3.1.0",
         "pino": "^8.16.2",
         "through2": "^4.0.2",
         "uuid": "^9.0.1"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "lodash.unset": "^4.5.2",
     "mongodb-client-encryption": "^2.9.0",
     "ndjson": "^2.0.0",
+    "p-limit": "^3.1.0",
     "pino": "^8.16.2",
     "through2": "^4.0.2",
     "uuid": "^9.0.1"


### PR DESCRIPTION
<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

## Pull Request Type
<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

The previous implementation was bogus, it was inteded to limit promise concurrency 5 by 5 but wasn't actually doing so, I've installed p-limit in order to actually implement concurrency limiting.

## PR Checklist

<!-- TODO: Include update for the CONTRIBUTING file up-to-date regarding information about the commit -->
- [X] The commit message follows our guidelines included in the [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-submit-a-pr)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other info

With the same configuration used in #224 I've seen the following changes in startup connection creation

### Previous implementation

**First startup**

This startup creates collections and indexes for the first time

![Screenshot 2023-11-22 alle 12 52 51](https://github.com/mia-platform/crud-service/assets/7142570/1590da39-8fa1-4c63-83d5-b9427725b0f3)

**Second startup**

Here there are no datamodels changes, it's all due to the `collection.indexes()` invocation

![Screenshot 2023-11-22 alle 12 54 23](https://github.com/mia-platform/crud-service/assets/7142570/ad3ef543-acec-4b96-bed6-1fa8be4954a7)


### New implementation

**First startup**

This startup creates collections and indexes for the first time

![Screenshot 2023-11-22 alle 12 53 38](https://github.com/mia-platform/crud-service/assets/7142570/7929eadf-47ce-4a12-b616-8507228e3299)

**Second startup**

Here there are no datamodels changes, it's all due to the `collection.indexes()` invocation

![Screenshot 2023-11-22 alle 12 53 47](https://github.com/mia-platform/crud-service/assets/7142570/7e6ccd05-c1dc-4c4a-b133-aafa7fc23721)
