### PR TITLE
fix: change shell command to generate masterkey

### DIFF
--- a/docs/30_Encryption_configuration.md
+++ b/docs/30_Encryption_configuration.md
@@ -125,7 +125,7 @@ try {
 
 #### How to generate a local master key using Shell Command
 ```shell
-cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 96 | head -n 1 > YOUR_KEY_PATH
+LC_CTYPE=C tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 96 | head -1
 ```
 
 ## Migration and change of the configurations


### PR DESCRIPTION
<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

## Pull Request Type
<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] Other... Please describe:

## Description

I changed the command to generate masterKey on shell for Mia-Platform chart installation. The one before usually errors with: tr: Illegal byte sequence.

## PR Checklist

<!-- TODO: Include update for the CONTRIBUTING file up-to-date regarding information about the commit -->
- [X] The commit message follows our guidelines included in the [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-submit-a-pr)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Use this space to include more information about your pull request. If you don't need to add anything, feel free to remove this section. -->