### PR TITLE
refactor: resolve fastify deprecation warning

### DIFF
--- a/lib/httpInterface.js
+++ b/lib/httpInterface.js
@@ -310,7 +310,11 @@ async function handleCollectionImport(request, reply) {
     .filter(field => field.type === 'field')
     .map(({ fieldname, value }) => [fieldname, value]))
 
-  const { itemValidator, validateImportOptions } = reply.context.config
+  const {
+    log,
+    crudContext,
+    routeOptions: { config: { itemValidator, validateImportOptions } },
+  } = request
   const isValid = validateImportOptions(parsingOptions)
   if (!isValid) {
     return reply.getHttpError(BAD_REQUEST_ERROR_STATUS_CODE, `Invalid options`)
@@ -322,7 +326,7 @@ async function handleCollectionImport(request, reply) {
   }
 
   const { crudService, queryParser } = this
-  const { log, crudContext } = request
+  const { } = request
 
   let documentIndex = 0
   const parseDocument = through2.obj((chunk, _enc, callback) => {
@@ -397,7 +401,13 @@ async function handleGetListLookup(request, reply) {
     })
   }
 
-  const { query, headers, crudContext, log } = request
+  const {
+    query,
+    headers,
+    crudContext,
+    log,
+    routeOptions: { config: { replyType, streamValidator } },
+  } = request
 
   const {
     [QUERY]: clientQueryString,
@@ -435,7 +445,6 @@ async function handleGetListLookup(request, reply) {
   }
 
   const stateArr = state?.split(',')
-  const { replyType, streamValidator } = reply.context.config
   const contentType = replyType()
   const responseStringifiers = getFileMimeStringifiers(contentType)
   if (!responseStringifiers) {
@@ -471,7 +480,13 @@ async function handleGetList(request, reply) {
     })
   }
 
-  const { query, headers, crudContext, log } = request
+  const {
+    query,
+    headers,
+    crudContext,
+    log,
+    routeOptions: { config: { replyType, streamValidator } },
+  } = request
   const {
     [QUERY]: clientQueryString,
     [PROJECTION]: clientProjectionString = '',
@@ -483,7 +498,6 @@ async function handleGetList(request, reply) {
     ...otherParams
   } = query
   const { acl_rows, acl_read_columns, accept } = headers
-  const { replyType, streamValidator } = reply.context.config
   const contentType = replyType(accept)
 
   const responseStringifiers = getFileMimeStringifiers(contentType, {})
@@ -539,12 +553,13 @@ async function handleGetId(request, reply) {
     })
   }
 
-  const { crudContext, log } = request
+  const {
+    crudContext,
+    log,
+    routeOptions: { config: { itemValidator } },
+  } = request
   const docId = request.params.id
   const { acl_rows, acl_read_columns } = request.headers
-  const {
-    itemValidator,
-  } = reply.context.config
 
   const {
     [QUERY]: clientQueryString,
@@ -696,7 +711,15 @@ async function handlePatchId(request, reply) {
     })
   }
 
-  const { query, headers, params, crudContext, log } = request
+  const {
+    query,
+    headers,
+    params,
+    crudContext,
+    log,
+    routeOptions: { config: { itemValidator } },
+  } = request
+
   const {
     [QUERY]: clientQueryString,
     [STATE]: state,
@@ -707,9 +730,6 @@ async function handlePatchId(request, reply) {
     acl_write_columns: aclWriteColumns,
     acl_read_columns: aclColumns = '',
   } = headers
-  const {
-    itemValidator,
-  } = reply.context.config
 
   const commands = request.body
 
@@ -765,7 +785,7 @@ async function handlePatchMany(request) {
   return nModified
 }
 
-async function handleUpsertOne(request, reply) {
+async function handleUpsertOne(request) {
   if (this.customMetrics) {
     this.customMetrics.collectionInvocation.inc({
       collection_name: this.modelName,
@@ -773,7 +793,13 @@ async function handleUpsertOne(request, reply) {
     })
   }
 
-  const { query, headers, crudContext, log } = request
+  const {
+    query,
+    headers,
+    crudContext,
+    log,
+    routeOptions: { config: { itemValidator } },
+  } = request
   const {
     [QUERY]: clientQueryString,
     [STATE]: state,
@@ -784,9 +810,6 @@ async function handleUpsertOne(request, reply) {
     acl_write_columns: aclWriteColumns,
     acl_read_columns: aclColumns = '',
   } = headers
-  const {
-    itemValidator,
-  } = reply.context.config
 
   const commands = request.body
 

--- a/lib/httpInterface.js
+++ b/lib/httpInterface.js
@@ -326,7 +326,6 @@ async function handleCollectionImport(request, reply) {
   }
 
   const { crudService, queryParser } = this
-  const { } = request
 
   let documentIndex = 0
   const parseDocument = through2.obj((chunk, _enc, callback) => {


### PR DESCRIPTION

## Pull Request Type
<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

This PR resolves a deprecation warning that may clutter service logs when receiving lots of requests, the warning is the one saying:

```(node:82929) [FSTDEP019] FastifyDeprecation: reply.context property access is deprecated. Please use "reply.routeOptions.config" or "reply.routeOptions.schema" instead for accessing Route settings. The "reply.context" will be removed in `fastify@5`.```

https://fastify.dev/docs/latest/Reference/Reply/

## PR Checklist

<!-- TODO: Include update for the CONTRIBUTING file up-to-date regarding information about the commit -->
- [X] The commit message follows our guidelines included in the [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-submit-a-pr)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
