### PR TITLE
feat: _useEstimate query operator in /count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- [#237](https://github.com/mia-platform/crud-service/issues/237): casting values in `_q` queries are now even if case of nested fields
+
 ## 6.9.6 - 2024-01-23
 
 ### Fixed

--- a/lib/CrudService.js
+++ b/lib/CrudService.js
@@ -421,7 +421,8 @@ class CrudService {
     return this._mongoCollection.countDocuments(searchQuery, options)
   }
 
-  async estimatedDocumentCount() {
+  async estimatedDocumentCount(context) {
+    context.log.debug({}, 'estimatedDocumentCount operation requested')
     return this._mongoCollection.estimatedDocumentCount()
   }
 

--- a/lib/CrudService.js
+++ b/lib/CrudService.js
@@ -421,6 +421,10 @@ class CrudService {
     return this._mongoCollection.countDocuments(searchQuery, options)
   }
 
+  async estimatedDocumentCount() {
+    return this._mongoCollection.estimatedDocumentCount()
+  }
+
   async deleteAll(context, query, _states) {
     const stateQuery = getStateQuery(_states)
     const isQueryValid = query && Object.keys(query).length > 0

--- a/lib/JSONSchemaGenerator.js
+++ b/lib/JSONSchemaGenerator.js
@@ -51,6 +51,7 @@ const {
   UPDATEDAT,
   CREATORID,
   CREATEDAT,
+  USE_ESTIMATE,
 } = require('./consts')
 const {
   stateCreateValidationSchema,
@@ -121,6 +122,12 @@ module.exports = class JSONSchemaGenerator {
     const countAndQueryValidation = {
       [MONGOID]: { ...mongoIdTypeValidator[idType]() },
       ...structuredClone(deleteProperties),
+      [USE_ESTIMATE]: {
+        type: 'boolean',
+        enum: [true, false],
+        description: 'If `true` returns the count of all documents in the collection, based on the metadata of the collection. It works only there are no other query parameters.',
+        default: false,
+      },
     }
 
     this._idType = idType

--- a/lib/QueryParser.js
+++ b/lib/QueryParser.js
@@ -28,10 +28,12 @@ const {
   NORMAL_INDEX,
   JSON_SCHEMA_OBJECT_TYPE,
   DATE,
-  DATE_FORMATS,
   OBJECTID,
   GEOPOINT,
 } = require('../lib/consts')
+const { getFieldDefinition, getFieldDefinitionNameFromQuery } = require('./QueryParser.utils')
+
+const ALLOWED_COMPLEX_TYPES = [ARRAY, RAWOBJECTTYPE, JSON_SCHEMA_OBJECT_TYPE, JSON_SCHEMA_ARRAY_TYPE]
 
 class QueryParser {
   constructor(collectionDefinition, pathsForRawSchema) {
@@ -186,6 +188,8 @@ callExists.supportedTypes = {
   ObjectId: true,
   Array: true,
   GeoPoint: true,
+  [RAWOBJECTTYPE]: true,
+  [JSON_SCHEMA_OBJECT_TYPE]: true,
 }
 
 function callElemMatch(value) {
@@ -231,25 +235,25 @@ function identity(value) { return value }
 // eslint-disable-next-line max-statements
 function traverse(fieldDefinition, traverseBinded, query) {
   for (const key of Object.keys(query)) {
-    const fieldType = fieldDefinition[key.split('.')[0]]
-    if (fieldType === RAWOBJECTTYPE || fieldType === ARRAY) { continue }
+    if (key.startsWith('$')) {
+      if (key === '$and' || key === '$or') {
+        query[key].forEach(traverseBinded)
+        continue
+      }
+      if (key === '$text') {
+        continue
+      }
 
-    if (key === '$and' || key === '$or') {
-      query[key].forEach(traverseBinded)
-      continue
-    }
-    if (key === '$text') {
-      continue
-    }
-
-    if (key[0] === '$') {
       throw new Error(`Unknown operator: ${key}`)
     }
-    if (!fieldDefinition[key]) {
+
+    const definition = getFieldDefinitionNameFromQuery(key)
+
+    if (!fieldDefinition[definition.split('.')[0]]) {
       throw new Error(`Unknown field: ${key}`)
     }
 
-    const type = fieldDefinition[key]
+    const type = fieldDefinition[definition]
     const castValueFunction = castValueFunctions[type] || identity
 
     const value = query[key]
@@ -261,11 +265,16 @@ function traverse(fieldDefinition, traverseBinded, query) {
 
     const queryKey = Object.keys(value)
     for (const operator of queryKey) {
+      if (
+        !operator.startsWith('$') && ALLOWED_COMPLEX_TYPES.includes(type)) {
+        continue
+      }
+
       const traverseOperatorFunction = traverseOperatorFunctions[operator]
       if (!traverseOperatorFunction) {
         throw new Error(`Unsupported operator: ${operator}`)
       }
-      if (!traverseOperatorFunction.supportedTypes[type]) {
+      if (Boolean(type) && !traverseOperatorFunction.supportedTypes[type]) {
         throw new Error(`Unsupported operator: ${operator} for ${type} field`)
       }
 
@@ -295,48 +304,6 @@ function traverseBody(fieldDefinition, nullableFields, doc) {
 
     doc[key] = castValueFunction(value)
   }
-}
-
-function getFieldDefinitionCompatibility(collectionDefinition) {
-  return collectionDefinition
-    .fields
-    .reduce((acc, field) => {
-      acc[field.name] = field.type
-      return acc
-    }, {})
-}
-
-function getFieldDefinition(collectionDefinition) {
-  if (!collectionDefinition.schema) {
-    return getFieldDefinitionCompatibility(collectionDefinition)
-  }
-
-  return Object
-    .entries(collectionDefinition.schema.properties)
-    .reduce((acc, [propertyName, jsonSchema]) => {
-      if (jsonSchema.__mia_configuration?.type) {
-        acc[propertyName] = jsonSchema.__mia_configuration.type
-        return acc
-      }
-
-      if (jsonSchema.type === 'string' && DATE_FORMATS.includes(jsonSchema.format ?? '')) {
-        acc[propertyName] = DATE
-        return acc
-      }
-
-      if (jsonSchema.type === JSON_SCHEMA_OBJECT_TYPE) {
-        acc[propertyName] = RAWOBJECTTYPE
-        return acc
-      }
-
-      if (jsonSchema.type === JSON_SCHEMA_ARRAY_TYPE) {
-        acc[propertyName] = ARRAY
-        return acc
-      }
-
-      acc[propertyName] = jsonSchema.type
-      return acc
-    }, {})
 }
 
 function getNullableFieldsCompatibility(collectionDefinition) {

--- a/lib/QueryParser.utils.js
+++ b/lib/QueryParser.utils.js
@@ -1,0 +1,83 @@
+/*
+* Copyright 2023 Mia s.r.l.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable no-underscore-dangle */
+
+'use strict'
+
+const { DATE_FORMATS, DATE, JSON_SCHEMA_OBJECT_TYPE, RAWOBJECTTYPE, JSON_SCHEMA_ARRAY_TYPE, ARRAY } = require('./consts')
+
+function getFieldDefinitionNameFromQuery(query = '') {
+  return query.split('.')
+    .filter(chunk => !/[\d]+/.test(chunk))
+    .join('.')
+}
+
+function getFieldDefinition(collectionDefinition) {
+  function processJsonSchemaProperties(properties = {}, parentPath = '') {
+    let result = {}
+
+    for (const [key, value] of Object.entries(properties)) {
+      const path = parentPath ? `${parentPath}.${key}` : key
+
+      if (value.__mia_configuration) {
+        result[path] = value.__mia_configuration.type ?? value.type
+      } else {
+        switch (value?.type) {
+        case 'string': {
+          result[path] = DATE_FORMATS.includes(value.format ?? '') ? DATE : 'string'
+          break
+        }
+        case JSON_SCHEMA_ARRAY_TYPE: {
+          result[path] = ARRAY
+          if (value.items?.type === JSON_SCHEMA_OBJECT_TYPE) {
+            result = { ...result, ...processJsonSchemaProperties(value.items?.properties, path) }
+          }
+          break
+        }
+        case JSON_SCHEMA_OBJECT_TYPE: {
+          result[path] = RAWOBJECTTYPE
+          result = { ...result, ...processJsonSchemaProperties(value?.properties, path) }
+          break
+        }
+        default:
+          result[path] = value.type
+          break
+        }
+      }
+    }
+
+    return result
+  }
+
+  if (!collectionDefinition.schema) {
+    return collectionDefinition.fields
+      .reduce((acc, field) => {
+        acc[field.name] = field.type
+        if (field.type === RAWOBJECTTYPE) {
+          return { ...acc, ...processJsonSchemaProperties(field.schema?.properties, field.name) }
+        } else if (field.type === ARRAY && field.items?.type === RAWOBJECTTYPE) {
+          return { ...acc, ...processJsonSchemaProperties(field.items.schema?.properties, field.name) }
+        }
+
+        return acc
+      }, {})
+  }
+
+  return processJsonSchemaProperties(collectionDefinition.schema.properties)
+}
+
+module.exports = { getFieldDefinition, getFieldDefinitionNameFromQuery }

--- a/lib/consts.js
+++ b/lib/consts.js
@@ -60,6 +60,7 @@ module.exports = Object.freeze({
   STATE: '_st',
   MONGOID: '_id',
   RAW_PROJECTION: '_rawp',
+  USE_ESTIMATE: '_useEstimate',
 
   // Patch commands
   SETCMD: '$set',

--- a/lib/httpInterface.js
+++ b/lib/httpInterface.js
@@ -700,7 +700,7 @@ async function handleCount(request) {
   const { acl_rows } = headers
 
   if (useEstimate) {
-    return this.crudService.estimatedDocumentCount()
+    return this.crudService.estimatedDocumentCount(crudContext)
   }
 
   const mongoQuery = resolveMongoQuery(this.queryParser, clientQueryString, acl_rows, otherParams, false)

--- a/lib/httpInterface.js
+++ b/lib/httpInterface.js
@@ -44,6 +44,7 @@ const {
   __STATE__,
   SCHEMA_CUSTOM_KEYWORDS,
   rawProjectionDictionary,
+  USE_ESTIMATE,
 } = require('./consts')
 
 const getAccept = require('./acceptHeaderParser')
@@ -692,9 +693,15 @@ async function handleCount(request) {
   const {
     [QUERY]: clientQueryString,
     [STATE]: state,
+    [USE_ESTIMATE]: useEstimate,
     ...otherParams
   } = query
+
   const { acl_rows } = headers
+
+  if (useEstimate) {
+    return this.crudService.estimatedDocumentCount()
+  }
 
   const mongoQuery = resolveMongoQuery(this.queryParser, clientQueryString, acl_rows, otherParams, false)
 

--- a/tests/collectionDefinitions/books.js
+++ b/tests/collectionDefinitions/books.js
@@ -219,6 +219,13 @@ module.exports = {
       type: 'Array',
       items: {
         type: 'RawObject',
+        schema: {
+          properties: {
+            edition: { type: 'number' },
+            date: { type: 'string', format: 'date-time' },
+          },
+          additionalProperties: true,
+        },
       },
       required: false,
       nullable: true,

--- a/tests/collectionDefinitions/books_encrypted.js
+++ b/tests/collectionDefinitions/books_encrypted.js
@@ -127,6 +127,7 @@ module.exports = {
               properties: {
                 arrayItemObjectChildNumber: { type: 'number' },
                 anotherNumber: { type: 'number' },
+                anotherObject: { type: 'object', nullable: true },
               },
               additionalProperties: true,
               required: ['arrayItemObjectChildNumber'],

--- a/tests/expectedSchemas/booksBulkSchema.js
+++ b/tests/expectedSchemas/booksBulkSchema.js
@@ -308,6 +308,15 @@ module.exports = {
               'items': {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
               'nullable': true,
@@ -315,6 +324,15 @@ module.exports = {
             {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
           ],

--- a/tests/expectedSchemas/booksChangeStateManySchema.js
+++ b/tests/expectedSchemas/booksChangeStateManySchema.js
@@ -282,6 +282,15 @@ module.exports = {
                   'items': {
                     'type': 'object',
                     'additionalProperties': true,
+                    'properties': {
+                      'edition': {
+                        'type': 'number',
+                      },
+                      'date': {
+                        'type': 'string',
+                        'format': 'date-time',
+                      },
+                    },
                     'nullable': true,
                   },
                   'nullable': true,
@@ -289,6 +298,15 @@ module.exports = {
                 {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
               ],
@@ -483,6 +501,27 @@ module.exports = {
             },
             'attachments\\.\\d+\\.more\\.\\d+$': {
               'type': 'string',
+            },
+            'editionsDates\\.\\d+$': {
+              'type': 'object',
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
+              'additionalProperties': true,
+            },
+            'editionsDates\\.\\d+\\..+$': true,
+            'editionsDates\\.\\d+\\.edition$': {
+              'type': 'number',
+            },
+            'editionsDates\\.\\d+\\.date$': {
+              'type': 'string',
+              'format': 'date-time',
             },
           },
         },

--- a/tests/expectedSchemas/booksChangeStateSchema.js
+++ b/tests/expectedSchemas/booksChangeStateSchema.js
@@ -242,6 +242,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -249,6 +258,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -323,6 +341,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,

--- a/tests/expectedSchemas/booksCountSchema.js
+++ b/tests/expectedSchemas/booksCountSchema.js
@@ -238,6 +238,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -245,6 +254,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -325,6 +343,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,

--- a/tests/expectedSchemas/booksDeleteListSchema.js
+++ b/tests/expectedSchemas/booksDeleteListSchema.js
@@ -232,6 +232,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -239,6 +248,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -319,6 +337,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,

--- a/tests/expectedSchemas/booksDeleteSchema.js
+++ b/tests/expectedSchemas/booksDeleteSchema.js
@@ -242,6 +242,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -249,6 +258,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -329,6 +347,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,

--- a/tests/expectedSchemas/booksExportSchema.js
+++ b/tests/expectedSchemas/booksExportSchema.js
@@ -249,6 +249,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -256,6 +265,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -369,6 +387,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,
@@ -683,6 +709,15 @@ module.exports = {
                 'items': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
                 'nullable': true,
@@ -690,6 +725,15 @@ module.exports = {
               {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
             ],

--- a/tests/expectedSchemas/booksGetItemSchema.js
+++ b/tests/expectedSchemas/booksGetItemSchema.js
@@ -242,6 +242,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -249,6 +258,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -337,6 +355,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,
@@ -649,6 +675,15 @@ module.exports = {
               'items': {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
               'nullable': true,
@@ -656,6 +691,15 @@ module.exports = {
             {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
           ],

--- a/tests/expectedSchemas/booksGetListLookupSchema.js
+++ b/tests/expectedSchemas/booksGetListLookupSchema.js
@@ -215,6 +215,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -222,6 +231,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -333,6 +351,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,
@@ -647,6 +673,15 @@ module.exports = {
                 'items': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
                 'nullable': true,
@@ -654,6 +689,15 @@ module.exports = {
               {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
             ],

--- a/tests/expectedSchemas/booksGetListSchema.js
+++ b/tests/expectedSchemas/booksGetListSchema.js
@@ -239,6 +239,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -246,6 +255,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -361,6 +379,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,
@@ -675,6 +701,15 @@ module.exports = {
                 'items': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
                 'nullable': true,
@@ -682,6 +717,15 @@ module.exports = {
               {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
             ],

--- a/tests/expectedSchemas/booksNewBulkSchema.js
+++ b/tests/expectedSchemas/booksNewBulkSchema.js
@@ -318,6 +318,15 @@ module.exports = {
               'items': {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
               'nullable': true,
@@ -325,6 +334,15 @@ module.exports = {
             {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
           ],

--- a/tests/expectedSchemas/booksNewChangeStateManySchema.js
+++ b/tests/expectedSchemas/booksNewChangeStateManySchema.js
@@ -312,6 +312,15 @@ module.exports = {
                   'items': {
                     'type': 'object',
                     'additionalProperties': true,
+                    'properties': {
+                      'edition': {
+                        'type': 'number',
+                      },
+                      'date': {
+                        'type': 'string',
+                        'format': 'date-time',
+                      },
+                    },
                     'nullable': true,
                   },
                   'nullable': true,
@@ -319,6 +328,15 @@ module.exports = {
                 {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
               ],
@@ -513,6 +531,27 @@ module.exports = {
             },
             'attachments\\.\\d+\\.more\\.\\d+$': {
               'type': 'string',
+            },
+            'editionsDates\\.\\d+$': {
+              'type': 'object',
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
+              'additionalProperties': true,
+            },
+            'editionsDates\\.\\d+\\..+$': true,
+            'editionsDates\\.\\d+\\.edition$': {
+              'type': 'number',
+            },
+            'editionsDates\\.\\d+\\.date$': {
+              'type': 'string',
+              'format': 'date-time',
             },
           },
         },

--- a/tests/expectedSchemas/booksNewChangeStateSchema.js
+++ b/tests/expectedSchemas/booksNewChangeStateSchema.js
@@ -272,6 +272,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -279,6 +288,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -353,6 +371,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,

--- a/tests/expectedSchemas/booksNewCountSchema.js
+++ b/tests/expectedSchemas/booksNewCountSchema.js
@@ -268,6 +268,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -275,6 +284,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -355,6 +373,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,

--- a/tests/expectedSchemas/booksNewDeleteListSchema.js
+++ b/tests/expectedSchemas/booksNewDeleteListSchema.js
@@ -262,6 +262,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -269,6 +278,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -349,6 +367,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,

--- a/tests/expectedSchemas/booksNewDeleteSchema.js
+++ b/tests/expectedSchemas/booksNewDeleteSchema.js
@@ -272,6 +272,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -279,6 +288,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -359,6 +377,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,

--- a/tests/expectedSchemas/booksNewExportSchema.js
+++ b/tests/expectedSchemas/booksNewExportSchema.js
@@ -279,6 +279,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -286,6 +295,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -399,6 +417,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,
@@ -713,6 +739,15 @@ module.exports = {
                 'items': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
                 'nullable': true,
@@ -720,6 +755,15 @@ module.exports = {
               {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
             ],

--- a/tests/expectedSchemas/booksNewGetItemSchema.js
+++ b/tests/expectedSchemas/booksNewGetItemSchema.js
@@ -272,6 +272,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -279,6 +288,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -367,6 +385,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,
@@ -679,6 +705,15 @@ module.exports = {
               'items': {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
               'nullable': true,
@@ -686,6 +721,15 @@ module.exports = {
             {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
           ],

--- a/tests/expectedSchemas/booksNewGetListLookupSchema.js
+++ b/tests/expectedSchemas/booksNewGetListLookupSchema.js
@@ -225,6 +225,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -232,6 +241,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -343,6 +361,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,
@@ -657,6 +683,15 @@ module.exports = {
                 'items': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
                 'nullable': true,
@@ -664,6 +699,15 @@ module.exports = {
               {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
             ],

--- a/tests/expectedSchemas/booksNewGetListSchema.js
+++ b/tests/expectedSchemas/booksNewGetListSchema.js
@@ -269,6 +269,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -276,6 +285,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -391,6 +409,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,
@@ -705,6 +731,15 @@ module.exports = {
                 'items': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
                 'nullable': true,
@@ -712,6 +747,15 @@ module.exports = {
               {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
             ],

--- a/tests/expectedSchemas/booksNewPatchBulkSchema.js
+++ b/tests/expectedSchemas/booksNewPatchBulkSchema.js
@@ -279,6 +279,15 @@ module.exports = {
                   'items': {
                     'type': 'object',
                     'additionalProperties': true,
+                    'properties': {
+                      'edition': {
+                        'type': 'number',
+                      },
+                      'date': {
+                        'type': 'string',
+                        'format': 'date-time',
+                      },
+                    },
                     'nullable': true,
                   },
                   'nullable': true,
@@ -286,6 +295,15 @@ module.exports = {
                 {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
               ],
@@ -550,6 +568,27 @@ module.exports = {
             },
             'attachments\\.\\d+\\.more\\.\\d+$': {
               'type': 'string',
+            },
+            'editionsDates\\.\\d+$': {
+              'type': 'object',
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
+              'additionalProperties': true,
+            },
+            'editionsDates\\.\\d+\\..+$': true,
+            'editionsDates\\.\\d+\\.edition$': {
+              'type': 'number',
+            },
+            'editionsDates\\.\\d+\\.date$': {
+              'type': 'string',
+              'format': 'date-time',
             },
           },
           'additionalProperties': false,
@@ -846,6 +885,15 @@ module.exports = {
                       'items': {
                         'type': 'object',
                         'additionalProperties': true,
+                        'properties': {
+                          'edition': {
+                            'type': 'number',
+                          },
+                          'date': {
+                            'type': 'string',
+                            'format': 'date-time',
+                          },
+                        },
                         'nullable': true,
                       },
                       'nullable': true,
@@ -853,6 +901,15 @@ module.exports = {
                     {
                       'type': 'object',
                       'additionalProperties': true,
+                      'properties': {
+                        'edition': {
+                          'type': 'number',
+                        },
+                        'date': {
+                          'type': 'string',
+                          'format': 'date-time',
+                        },
+                      },
                       'nullable': true,
                     },
                   ],
@@ -954,9 +1011,27 @@ module.exports = {
                 'editionsDates.$.replace': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                 },
                 'editionsDates.$.merge': {
                   'type': 'object',
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'additionalProperties': true,
                 },
                 'signature.name': {
@@ -1196,6 +1271,27 @@ module.exports = {
                 'attachments\\.\\d+\\.more\\.\\d+$': {
                   'type': 'string',
                 },
+                'editionsDates\\.\\d+$': {
+                  'type': 'object',
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
+                  'additionalProperties': true,
+                },
+                'editionsDates\\.\\d+\\..+$': true,
+                'editionsDates\\.\\d+\\.edition$': {
+                  'type': 'number',
+                },
+                'editionsDates\\.\\d+\\.date$': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
                 'metadata\\.exampleArrayOfArray\\.\\d+\\.\\$\\.replace$': {
                   'type': 'string',
                 },
@@ -1310,6 +1406,12 @@ module.exports = {
                     true,
                   ],
                 },
+                '^editionsDates\\..+': {
+                  'type': 'boolean',
+                  'enum': [
+                    true,
+                  ],
+                },
               },
             },
             '$inc': {
@@ -1349,6 +1451,9 @@ module.exports = {
                 'attachments\\.\\d+\\.stuff$': {
                   'type': 'number',
                 },
+                'editionsDates\\.\\d+\\.edition$': {
+                  'type': 'number',
+                },
               },
             },
             '$mul': {
@@ -1386,6 +1491,9 @@ module.exports = {
                   'type': 'number',
                 },
                 'attachments\\.\\d+\\.stuff$': {
+                  'type': 'number',
+                },
+                'editionsDates\\.\\d+\\.edition$': {
                   'type': 'number',
                 },
               },
@@ -1459,6 +1567,15 @@ module.exports = {
                 'editionsDates': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                 },
                 'metadata.somethingArrayObject': {
                   'type': 'object',
@@ -1502,6 +1619,7 @@ module.exports = {
                 'attachments\\.\\d+\\.more$': {
                   'type': 'string',
                 },
+                'editionsDates\\.\\d+\\..+$': {},
               },
               'additionalProperties': false,
             },
@@ -1582,6 +1700,15 @@ module.exports = {
                 'editionsDates': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                 },
                 'metadata.somethingArrayObject': {
                   'type': 'object',
@@ -1677,6 +1804,17 @@ module.exports = {
                     {
                       'type': 'string',
                     },
+                    {
+                      'type': 'object',
+                      'patternProperties': {
+                        '^$': {},
+                      },
+                    },
+                  ],
+                },
+                'editionsDates\\.\\d+\\..+$': {
+                  'oneOf': [
+                    {},
                     {
                       'type': 'object',
                       'patternProperties': {
@@ -1765,6 +1903,15 @@ module.exports = {
                 'editionsDates': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                 },
                 'metadata.somethingArrayObject': {
                   'type': 'object',
@@ -1860,6 +2007,17 @@ module.exports = {
                     {
                       'type': 'string',
                     },
+                    {
+                      'type': 'object',
+                      'patternProperties': {
+                        '^$': {},
+                      },
+                    },
+                  ],
+                },
+                'editionsDates\\.\\d+\\..+$': {
+                  'oneOf': [
+                    {},
                     {
                       'type': 'object',
                       'patternProperties': {

--- a/tests/expectedSchemas/booksNewPatchManySchema.js
+++ b/tests/expectedSchemas/booksNewPatchManySchema.js
@@ -268,6 +268,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -275,6 +284,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -355,6 +373,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,
@@ -652,6 +678,15 @@ module.exports = {
                 'items': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
                 'nullable': true,
@@ -659,6 +694,15 @@ module.exports = {
               {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
             ],
@@ -760,9 +804,27 @@ module.exports = {
           'editionsDates.$.replace': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'editionsDates.$.merge': {
             'type': 'object',
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'additionalProperties': true,
           },
           'signature.name': {
@@ -1002,6 +1064,27 @@ module.exports = {
           'attachments\\.\\d+\\.more\\.\\d+$': {
             'type': 'string',
           },
+          'editionsDates\\.\\d+$': {
+            'type': 'object',
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
+            'additionalProperties': true,
+          },
+          'editionsDates\\.\\d+\\..+$': true,
+          'editionsDates\\.\\d+\\.edition$': {
+            'type': 'number',
+          },
+          'editionsDates\\.\\d+\\.date$': {
+            'type': 'string',
+            'format': 'date-time',
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+\\.\\$\\.replace$': {
             'type': 'string',
           },
@@ -1116,6 +1199,12 @@ module.exports = {
               true,
             ],
           },
+          '^editionsDates\\..+': {
+            'type': 'boolean',
+            'enum': [
+              true,
+            ],
+          },
         },
       },
       '$inc': {
@@ -1155,6 +1244,9 @@ module.exports = {
           'attachments\\.\\d+\\.stuff$': {
             'type': 'number',
           },
+          'editionsDates\\.\\d+\\.edition$': {
+            'type': 'number',
+          },
         },
       },
       '$mul': {
@@ -1192,6 +1284,9 @@ module.exports = {
             'type': 'number',
           },
           'attachments\\.\\d+\\.stuff$': {
+            'type': 'number',
+          },
+          'editionsDates\\.\\d+\\.edition$': {
             'type': 'number',
           },
         },
@@ -1265,6 +1360,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1308,6 +1412,7 @@ module.exports = {
           'attachments\\.\\d+\\.more$': {
             'type': 'string',
           },
+          'editionsDates\\.\\d+\\..+$': {},
         },
         'additionalProperties': false,
       },
@@ -1388,6 +1493,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1483,6 +1597,17 @@ module.exports = {
               {
                 'type': 'string',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'editionsDates\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {
@@ -1571,6 +1696,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1666,6 +1800,17 @@ module.exports = {
               {
                 'type': 'string',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'editionsDates\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {

--- a/tests/expectedSchemas/booksNewPatchSchema.js
+++ b/tests/expectedSchemas/booksNewPatchSchema.js
@@ -272,6 +272,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -279,6 +288,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -359,6 +377,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,
@@ -656,6 +682,15 @@ module.exports = {
                 'items': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
                 'nullable': true,
@@ -663,6 +698,15 @@ module.exports = {
               {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
             ],
@@ -764,9 +808,27 @@ module.exports = {
           'editionsDates.$.replace': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'editionsDates.$.merge': {
             'type': 'object',
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'additionalProperties': true,
           },
           'signature.name': {
@@ -1006,6 +1068,27 @@ module.exports = {
           'attachments\\.\\d+\\.more\\.\\d+$': {
             'type': 'string',
           },
+          'editionsDates\\.\\d+$': {
+            'type': 'object',
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
+            'additionalProperties': true,
+          },
+          'editionsDates\\.\\d+\\..+$': true,
+          'editionsDates\\.\\d+\\.edition$': {
+            'type': 'number',
+          },
+          'editionsDates\\.\\d+\\.date$': {
+            'type': 'string',
+            'format': 'date-time',
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+\\.\\$\\.replace$': {
             'type': 'string',
           },
@@ -1120,6 +1203,12 @@ module.exports = {
               true,
             ],
           },
+          '^editionsDates\\..+': {
+            'type': 'boolean',
+            'enum': [
+              true,
+            ],
+          },
         },
       },
       '$inc': {
@@ -1159,6 +1248,9 @@ module.exports = {
           'attachments\\.\\d+\\.stuff$': {
             'type': 'number',
           },
+          'editionsDates\\.\\d+\\.edition$': {
+            'type': 'number',
+          },
         },
       },
       '$mul': {
@@ -1196,6 +1288,9 @@ module.exports = {
             'type': 'number',
           },
           'attachments\\.\\d+\\.stuff$': {
+            'type': 'number',
+          },
+          'editionsDates\\.\\d+\\.edition$': {
             'type': 'number',
           },
         },
@@ -1269,6 +1364,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1312,6 +1416,7 @@ module.exports = {
           'attachments\\.\\d+\\.more$': {
             'type': 'string',
           },
+          'editionsDates\\.\\d+\\..+$': {},
         },
         'additionalProperties': false,
       },
@@ -1392,6 +1497,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1487,6 +1601,17 @@ module.exports = {
               {
                 'type': 'string',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'editionsDates\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {
@@ -1575,6 +1700,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1670,6 +1804,17 @@ module.exports = {
               {
                 'type': 'string',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'editionsDates\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {
@@ -1992,6 +2137,15 @@ module.exports = {
               'items': {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
               'nullable': true,
@@ -1999,6 +2153,15 @@ module.exports = {
             {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
           ],

--- a/tests/expectedSchemas/booksNewPostSchema.js
+++ b/tests/expectedSchemas/booksNewPostSchema.js
@@ -316,6 +316,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -323,6 +332,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],

--- a/tests/expectedSchemas/booksNewUpsertOneSchema.js
+++ b/tests/expectedSchemas/booksNewUpsertOneSchema.js
@@ -262,6 +262,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -269,6 +278,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -349,6 +367,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,
@@ -646,6 +672,15 @@ module.exports = {
                 'items': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
                 'nullable': true,
@@ -653,6 +688,15 @@ module.exports = {
               {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
             ],
@@ -754,9 +798,27 @@ module.exports = {
           'editionsDates.$.replace': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'editionsDates.$.merge': {
             'type': 'object',
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'additionalProperties': true,
           },
           'signature.name': {
@@ -996,6 +1058,27 @@ module.exports = {
           'attachments\\.\\d+\\.more\\.\\d+$': {
             'type': 'string',
           },
+          'editionsDates\\.\\d+$': {
+            'type': 'object',
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
+            'additionalProperties': true,
+          },
+          'editionsDates\\.\\d+\\..+$': true,
+          'editionsDates\\.\\d+\\.edition$': {
+            'type': 'number',
+          },
+          'editionsDates\\.\\d+\\.date$': {
+            'type': 'string',
+            'format': 'date-time',
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+\\.\\$\\.replace$': {
             'type': 'string',
           },
@@ -1110,6 +1193,12 @@ module.exports = {
               true,
             ],
           },
+          '^editionsDates\\..+': {
+            'type': 'boolean',
+            'enum': [
+              true,
+            ],
+          },
         },
       },
       '$inc': {
@@ -1149,6 +1238,9 @@ module.exports = {
           'attachments\\.\\d+\\.stuff$': {
             'type': 'number',
           },
+          'editionsDates\\.\\d+\\.edition$': {
+            'type': 'number',
+          },
         },
       },
       '$mul': {
@@ -1186,6 +1278,9 @@ module.exports = {
             'type': 'number',
           },
           'attachments\\.\\d+\\.stuff$': {
+            'type': 'number',
+          },
+          'editionsDates\\.\\d+\\.edition$': {
             'type': 'number',
           },
         },
@@ -1259,6 +1354,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1302,6 +1406,7 @@ module.exports = {
           'attachments\\.\\d+\\.more$': {
             'type': 'string',
           },
+          'editionsDates\\.\\d+\\..+$': {},
         },
         'additionalProperties': false,
       },
@@ -1382,6 +1487,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1477,6 +1591,17 @@ module.exports = {
               {
                 'type': 'string',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'editionsDates\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {
@@ -1565,6 +1690,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1660,6 +1794,17 @@ module.exports = {
               {
                 'type': 'string',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'editionsDates\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {
@@ -1960,6 +2105,15 @@ module.exports = {
                 'items': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
                 'nullable': true,
@@ -1967,6 +2121,15 @@ module.exports = {
               {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
             ],
@@ -2286,6 +2449,15 @@ module.exports = {
               'items': {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
               'nullable': true,
@@ -2293,6 +2465,15 @@ module.exports = {
             {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
           ],

--- a/tests/expectedSchemas/booksPatchBulkSchema.js
+++ b/tests/expectedSchemas/booksPatchBulkSchema.js
@@ -249,6 +249,15 @@ module.exports = {
                   'items': {
                     'type': 'object',
                     'additionalProperties': true,
+                    'properties': {
+                      'edition': {
+                        'type': 'number',
+                      },
+                      'date': {
+                        'type': 'string',
+                        'format': 'date-time',
+                      },
+                    },
                     'nullable': true,
                   },
                   'nullable': true,
@@ -256,6 +265,15 @@ module.exports = {
                 {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
               ],
@@ -520,6 +538,27 @@ module.exports = {
             },
             'attachments\\.\\d+\\.more\\.\\d+$': {
               'type': 'string',
+            },
+            'editionsDates\\.\\d+$': {
+              'type': 'object',
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
+              'additionalProperties': true,
+            },
+            'editionsDates\\.\\d+\\..+$': true,
+            'editionsDates\\.\\d+\\.edition$': {
+              'type': 'number',
+            },
+            'editionsDates\\.\\d+\\.date$': {
+              'type': 'string',
+              'format': 'date-time',
             },
           },
           'additionalProperties': false,
@@ -806,6 +845,15 @@ module.exports = {
                       'items': {
                         'type': 'object',
                         'additionalProperties': true,
+                        'properties': {
+                          'edition': {
+                            'type': 'number',
+                          },
+                          'date': {
+                            'type': 'string',
+                            'format': 'date-time',
+                          },
+                        },
                         'nullable': true,
                       },
                       'nullable': true,
@@ -813,6 +861,15 @@ module.exports = {
                     {
                       'type': 'object',
                       'additionalProperties': true,
+                      'properties': {
+                        'edition': {
+                          'type': 'number',
+                        },
+                        'date': {
+                          'type': 'string',
+                          'format': 'date-time',
+                        },
+                      },
                       'nullable': true,
                     },
                   ],
@@ -914,9 +971,27 @@ module.exports = {
                 'editionsDates.$.replace': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                 },
                 'editionsDates.$.merge': {
                   'type': 'object',
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'additionalProperties': true,
                 },
                 'signature.name': {
@@ -1156,6 +1231,27 @@ module.exports = {
                 'attachments\\.\\d+\\.more\\.\\d+$': {
                   'type': 'string',
                 },
+                'editionsDates\\.\\d+$': {
+                  'type': 'object',
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
+                  'additionalProperties': true,
+                },
+                'editionsDates\\.\\d+\\..+$': true,
+                'editionsDates\\.\\d+\\.edition$': {
+                  'type': 'number',
+                },
+                'editionsDates\\.\\d+\\.date$': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
                 'metadata\\.exampleArrayOfArray\\.\\d+\\.\\$\\.replace$': {
                   'type': 'string',
                 },
@@ -1270,6 +1366,12 @@ module.exports = {
                     true,
                   ],
                 },
+                '^editionsDates\\..+': {
+                  'type': 'boolean',
+                  'enum': [
+                    true,
+                  ],
+                },
               },
             },
             '$inc': {
@@ -1309,6 +1411,9 @@ module.exports = {
                 'attachments\\.\\d+\\.stuff$': {
                   'type': 'number',
                 },
+                'editionsDates\\.\\d+\\.edition$': {
+                  'type': 'number',
+                },
               },
             },
             '$mul': {
@@ -1346,6 +1451,9 @@ module.exports = {
                   'type': 'number',
                 },
                 'attachments\\.\\d+\\.stuff$': {
+                  'type': 'number',
+                },
+                'editionsDates\\.\\d+\\.edition$': {
                   'type': 'number',
                 },
               },
@@ -1419,6 +1527,15 @@ module.exports = {
                 'editionsDates': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                 },
                 'metadata.somethingArrayObject': {
                   'type': 'object',
@@ -1462,6 +1579,7 @@ module.exports = {
                 'attachments\\.\\d+\\.more$': {
                   'type': 'string',
                 },
+                'editionsDates\\.\\d+\\..+$': {},
               },
               'additionalProperties': false,
             },
@@ -1542,6 +1660,15 @@ module.exports = {
                 'editionsDates': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                 },
                 'metadata.somethingArrayObject': {
                   'type': 'object',
@@ -1637,6 +1764,17 @@ module.exports = {
                     {
                       'type': 'string',
                     },
+                    {
+                      'type': 'object',
+                      'patternProperties': {
+                        '^$': {},
+                      },
+                    },
+                  ],
+                },
+                'editionsDates\\.\\d+\\..+$': {
+                  'oneOf': [
+                    {},
                     {
                       'type': 'object',
                       'patternProperties': {
@@ -1725,6 +1863,15 @@ module.exports = {
                 'editionsDates': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                 },
                 'metadata.somethingArrayObject': {
                   'type': 'object',
@@ -1820,6 +1967,17 @@ module.exports = {
                     {
                       'type': 'string',
                     },
+                    {
+                      'type': 'object',
+                      'patternProperties': {
+                        '^$': {},
+                      },
+                    },
+                  ],
+                },
+                'editionsDates\\.\\d+\\..+$': {
+                  'oneOf': [
+                    {},
                     {
                       'type': 'object',
                       'patternProperties': {

--- a/tests/expectedSchemas/booksPatchManySchema.js
+++ b/tests/expectedSchemas/booksPatchManySchema.js
@@ -238,6 +238,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -245,6 +254,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -325,6 +343,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,
@@ -612,6 +638,15 @@ module.exports = {
                 'items': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
                 'nullable': true,
@@ -619,6 +654,15 @@ module.exports = {
               {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
             ],
@@ -720,9 +764,27 @@ module.exports = {
           'editionsDates.$.replace': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'editionsDates.$.merge': {
             'type': 'object',
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'additionalProperties': true,
           },
           'signature.name': {
@@ -962,6 +1024,27 @@ module.exports = {
           'attachments\\.\\d+\\.more\\.\\d+$': {
             'type': 'string',
           },
+          'editionsDates\\.\\d+$': {
+            'type': 'object',
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
+            'additionalProperties': true,
+          },
+          'editionsDates\\.\\d+\\..+$': true,
+          'editionsDates\\.\\d+\\.edition$': {
+            'type': 'number',
+          },
+          'editionsDates\\.\\d+\\.date$': {
+            'type': 'string',
+            'format': 'date-time',
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+\\.\\$\\.replace$': {
             'type': 'string',
           },
@@ -1076,6 +1159,12 @@ module.exports = {
               true,
             ],
           },
+          '^editionsDates\\..+': {
+            'type': 'boolean',
+            'enum': [
+              true,
+            ],
+          },
         },
       },
       '$inc': {
@@ -1115,6 +1204,9 @@ module.exports = {
           'attachments\\.\\d+\\.stuff$': {
             'type': 'number',
           },
+          'editionsDates\\.\\d+\\.edition$': {
+            'type': 'number',
+          },
         },
       },
       '$mul': {
@@ -1152,6 +1244,9 @@ module.exports = {
             'type': 'number',
           },
           'attachments\\.\\d+\\.stuff$': {
+            'type': 'number',
+          },
+          'editionsDates\\.\\d+\\.edition$': {
             'type': 'number',
           },
         },
@@ -1225,6 +1320,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1268,6 +1372,7 @@ module.exports = {
           'attachments\\.\\d+\\.more$': {
             'type': 'string',
           },
+          'editionsDates\\.\\d+\\..+$': {},
         },
         'additionalProperties': false,
       },
@@ -1348,6 +1453,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1443,6 +1557,17 @@ module.exports = {
               {
                 'type': 'string',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'editionsDates\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {
@@ -1531,6 +1656,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1626,6 +1760,17 @@ module.exports = {
               {
                 'type': 'string',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'editionsDates\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {

--- a/tests/expectedSchemas/booksPatchSchema.js
+++ b/tests/expectedSchemas/booksPatchSchema.js
@@ -242,6 +242,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -249,6 +258,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -329,6 +347,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,
@@ -616,6 +642,15 @@ module.exports = {
                 'items': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
                 'nullable': true,
@@ -623,6 +658,15 @@ module.exports = {
               {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
             ],
@@ -724,9 +768,27 @@ module.exports = {
           'editionsDates.$.replace': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'editionsDates.$.merge': {
             'type': 'object',
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'additionalProperties': true,
           },
           'signature.name': {
@@ -966,6 +1028,27 @@ module.exports = {
           'attachments\\.\\d+\\.more\\.\\d+$': {
             'type': 'string',
           },
+          'editionsDates\\.\\d+$': {
+            'type': 'object',
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
+            'additionalProperties': true,
+          },
+          'editionsDates\\.\\d+\\..+$': true,
+          'editionsDates\\.\\d+\\.edition$': {
+            'type': 'number',
+          },
+          'editionsDates\\.\\d+\\.date$': {
+            'type': 'string',
+            'format': 'date-time',
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+\\.\\$\\.replace$': {
             'type': 'string',
           },
@@ -1080,6 +1163,12 @@ module.exports = {
               true,
             ],
           },
+          '^editionsDates\\..+': {
+            'type': 'boolean',
+            'enum': [
+              true,
+            ],
+          },
         },
       },
       '$inc': {
@@ -1119,6 +1208,9 @@ module.exports = {
           'attachments\\.\\d+\\.stuff$': {
             'type': 'number',
           },
+          'editionsDates\\.\\d+\\.edition$': {
+            'type': 'number',
+          },
         },
       },
       '$mul': {
@@ -1156,6 +1248,9 @@ module.exports = {
             'type': 'number',
           },
           'attachments\\.\\d+\\.stuff$': {
+            'type': 'number',
+          },
+          'editionsDates\\.\\d+\\.edition$': {
             'type': 'number',
           },
         },
@@ -1229,6 +1324,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1272,6 +1376,7 @@ module.exports = {
           'attachments\\.\\d+\\.more$': {
             'type': 'string',
           },
+          'editionsDates\\.\\d+\\..+$': {},
         },
         'additionalProperties': false,
       },
@@ -1352,6 +1457,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1447,6 +1561,17 @@ module.exports = {
               {
                 'type': 'string',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'editionsDates\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {
@@ -1535,6 +1660,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1630,6 +1764,17 @@ module.exports = {
               {
                 'type': 'string',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'editionsDates\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {
@@ -1952,6 +2097,15 @@ module.exports = {
               'items': {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
               'nullable': true,
@@ -1959,6 +2113,15 @@ module.exports = {
             {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
           ],

--- a/tests/expectedSchemas/booksPostSchema.js
+++ b/tests/expectedSchemas/booksPostSchema.js
@@ -306,6 +306,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -313,6 +322,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],

--- a/tests/expectedSchemas/booksUpsertOneSchema.js
+++ b/tests/expectedSchemas/booksUpsertOneSchema.js
@@ -232,6 +232,15 @@ module.exports = {
             'items': {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
             'nullable': true,
@@ -239,6 +248,15 @@ module.exports = {
           {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'nullable': true,
           },
         ],
@@ -319,6 +337,14 @@ module.exports = {
       },
       'attachments\\.\\d+\\.more\\.\\d+$': {
         'type': 'string',
+      },
+      'editionsDates\\.\\d+\\..+$': true,
+      'editionsDates\\.\\d+\\.edition$': {
+        'type': 'number',
+      },
+      'editionsDates\\.\\d+\\.date$': {
+        'type': 'string',
+        'format': 'date-time',
       },
     },
     'additionalProperties': false,
@@ -606,6 +632,15 @@ module.exports = {
                 'items': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
                 'nullable': true,
@@ -613,6 +648,15 @@ module.exports = {
               {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
             ],
@@ -714,9 +758,27 @@ module.exports = {
           'editionsDates.$.replace': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'editionsDates.$.merge': {
             'type': 'object',
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
             'additionalProperties': true,
           },
           'signature.name': {
@@ -956,6 +1018,27 @@ module.exports = {
           'attachments\\.\\d+\\.more\\.\\d+$': {
             'type': 'string',
           },
+          'editionsDates\\.\\d+$': {
+            'type': 'object',
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
+            'additionalProperties': true,
+          },
+          'editionsDates\\.\\d+\\..+$': true,
+          'editionsDates\\.\\d+\\.edition$': {
+            'type': 'number',
+          },
+          'editionsDates\\.\\d+\\.date$': {
+            'type': 'string',
+            'format': 'date-time',
+          },
           'metadata\\.exampleArrayOfArray\\.\\d+\\.\\$\\.replace$': {
             'type': 'string',
           },
@@ -1070,6 +1153,12 @@ module.exports = {
               true,
             ],
           },
+          '^editionsDates\\..+': {
+            'type': 'boolean',
+            'enum': [
+              true,
+            ],
+          },
         },
       },
       '$inc': {
@@ -1109,6 +1198,9 @@ module.exports = {
           'attachments\\.\\d+\\.stuff$': {
             'type': 'number',
           },
+          'editionsDates\\.\\d+\\.edition$': {
+            'type': 'number',
+          },
         },
       },
       '$mul': {
@@ -1146,6 +1238,9 @@ module.exports = {
             'type': 'number',
           },
           'attachments\\.\\d+\\.stuff$': {
+            'type': 'number',
+          },
+          'editionsDates\\.\\d+\\.edition$': {
             'type': 'number',
           },
         },
@@ -1219,6 +1314,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1262,6 +1366,7 @@ module.exports = {
           'attachments\\.\\d+\\.more$': {
             'type': 'string',
           },
+          'editionsDates\\.\\d+\\..+$': {},
         },
         'additionalProperties': false,
       },
@@ -1342,6 +1447,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1437,6 +1551,17 @@ module.exports = {
               {
                 'type': 'string',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'editionsDates\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {
@@ -1525,6 +1650,15 @@ module.exports = {
           'editionsDates': {
             'type': 'object',
             'additionalProperties': true,
+            'properties': {
+              'edition': {
+                'type': 'number',
+              },
+              'date': {
+                'type': 'string',
+                'format': 'date-time',
+              },
+            },
           },
           'metadata.somethingArrayObject': {
             'type': 'object',
@@ -1620,6 +1754,17 @@ module.exports = {
               {
                 'type': 'string',
               },
+              {
+                'type': 'object',
+                'patternProperties': {
+                  '^$': {},
+                },
+              },
+            ],
+          },
+          'editionsDates\\.\\d+\\..+$': {
+            'oneOf': [
+              {},
               {
                 'type': 'object',
                 'patternProperties': {
@@ -1910,6 +2055,15 @@ module.exports = {
                 'items': {
                   'type': 'object',
                   'additionalProperties': true,
+                  'properties': {
+                    'edition': {
+                      'type': 'number',
+                    },
+                    'date': {
+                      'type': 'string',
+                      'format': 'date-time',
+                    },
+                  },
                   'nullable': true,
                 },
                 'nullable': true,
@@ -1917,6 +2071,15 @@ module.exports = {
               {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
             ],
@@ -2236,6 +2399,15 @@ module.exports = {
               'items': {
                 'type': 'object',
                 'additionalProperties': true,
+                'properties': {
+                  'edition': {
+                    'type': 'number',
+                  },
+                  'date': {
+                    'type': 'string',
+                    'format': 'date-time',
+                  },
+                },
                 'nullable': true,
               },
               'nullable': true,
@@ -2243,6 +2415,15 @@ module.exports = {
             {
               'type': 'object',
               'additionalProperties': true,
+              'properties': {
+                'edition': {
+                  'type': 'number',
+                },
+                'date': {
+                  'type': 'string',
+                  'format': 'date-time',
+                },
+              },
               'nullable': true,
             },
           ],

--- a/tests/httpInterface.countList.test.js
+++ b/tests/httpInterface.countList.test.js
@@ -123,6 +123,20 @@ tap.test('HTTP GET /count', async t => {
       acl_rows: undefined,
       count: 0,
     },
+    {
+      name: 'query with _useEstimate parameter',
+      method: 'GET',
+      url: `${prefix}/count?_useEstimate=true`,
+      count: fixtures.length,
+      acl_rows: undefined,
+    },
+    {
+      name: 'query with _useEstimate parameter should ignore other query parameters',
+      method: 'GET',
+      url: `${prefix}/count?_useEstimate=true&_q=${JSON.stringify({ price: { $gt: Infinity } })}`,
+      count: fixtures.length,
+      acl_rows: undefined,
+    },
   ]
 
   t.plan(tests.length)

--- a/tests/httpInterface.getById.test.js
+++ b/tests/httpInterface.getById.test.js
@@ -104,6 +104,12 @@ tap.test('HTTP GET /<id>', async t => {
       found: false,
     },
     {
+      name: 'with stringified ISO Date in query filter',
+      url: `/${ID}?_q=${JSON.stringify({ 'editionsDates.date': { $lt: new Date('2020').toISOString() } })}`,
+      acl_rows: undefined,
+      found: HTTP_DOC,
+    },
+    {
       name: 'with acl_rows',
       url: `/${ID}`,
       acl_rows: [{ price: { $gt: MATCHING_PRICE } }],

--- a/tests/httpInterface.getList.test.js
+++ b/tests/httpInterface.getList.test.js
@@ -202,6 +202,12 @@ tap.test('HTTP GET /', async t => {
       found: HTTP_PUBLIC_FIXTURES.filter(f => f.price > 20 && !f.additionalInfo),
     },
     {
+      name: 'with stringified ISO Date in query filter',
+      url: `/?_q=${JSON.stringify({ 'editionsDates.date': { $lt: new Date('2020').toISOString() } })}`,
+      acl_rows: undefined,
+      found: HTTP_PUBLIC_FIXTURES.filter(f => Boolean(f.editionsDates)),
+    },
+    {
       name: 'with filter by additionalInfo nested with dot notation',
       url: `/?_q=${JSON.stringify({ 'additionalInfo.notes.mynote': 'good' })}`,
       acl_rows: undefined,
@@ -892,7 +898,7 @@ tap.test('HTTP GET / ', async t => {
 
   t.test('serialize correctly data on GET (a string should be casted to number to match schema)', async t => {
     const DOC = {
-      ...fixtures[0],
+      ...fixtures[1],
       // expected to be casted to number
       price: '44',
       ignoreMe: 'expect to be ignored',

--- a/tests/newCollectionDefinitions/books.js
+++ b/tests/newCollectionDefinitions/books.js
@@ -200,6 +200,10 @@ module.exports = {
         type: 'array',
         items: {
           type: 'object',
+          properties: {
+            edition: { type: 'number' },
+            date: { type: 'string', format: 'date-time' },
+          },
           additionalProperties: true,
         },
         nullable: true,

--- a/tests/queryParser.test.js
+++ b/tests/queryParser.test.js
@@ -25,14 +25,6 @@ const collectionDefinition = require('./newCollectionDefinitions/books')
 const projectsCollectionDefinition = require('./collectionDefinitions/projects')
 const generatePathFieldsForRawSchema = require('../lib/generatePathFieldsForRawSchema')
 
-const {
-  UPDATERID,
-  UPDATEDAT,
-  CREATORID,
-  CREATEDAT,
-  __STATE__,
-} = require('../lib/consts')
-
 tap.test('queryParser', t => {
   const nowDate = new Date()
   const nowString = nowDate.toISOString()
@@ -42,35 +34,6 @@ tap.test('queryParser', t => {
     collectionDefinition,
     generatePathFieldsForRawSchema(logger, collectionDefinition)
   )
-
-  t.test('has parsed the fields correctly', t => {
-    t.plan(1)
-
-    // eslint-disable-next-line no-underscore-dangle
-    t.strictSame(queryParser._fieldDefinition, {
-      _id: 'ObjectId',
-      name: 'string',
-      isbn: 'string',
-      price: 'number',
-      author: 'string',
-      authorAddressId: 'ObjectId',
-      isPromoted: 'boolean',
-      publishDate: 'Date',
-      position: 'GeoPoint',
-      tags: 'Array',
-      tagIds: 'Array',
-      additionalInfo: 'RawObject',
-      signature: 'RawObject',
-      metadata: 'RawObject',
-      attachments: 'Array',
-      editionsDates: 'Array',
-      [UPDATERID]: 'string',
-      [UPDATEDAT]: 'Date',
-      [CREATORID]: 'string',
-      [CREATEDAT]: 'Date',
-      [__STATE__]: 'string',
-    })
-  })
 
   t.test('parseAndCast', t => {
     const tests = []
@@ -363,11 +326,6 @@ tap.test('queryParser', t => {
           name: 'dot separated queries names should be allowed if type is RawObject',
           query: { 'additionalInfo.note': 'foo' },
           expected: { 'additionalInfo.note': 'foo' },
-        },
-        {
-          name: 'dot separated queries names should not be allowed if type is not RawObject',
-          query: { 'name.note': 'foo' },
-          throw: 'Unknown field: name.note',
         },
         {
           name: 'allow nested queries for type RawObject',

--- a/tests/queryParser.utils.test.js
+++ b/tests/queryParser.utils.test.js
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2023 Mia s.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict'
+
+const tap = require('tap')
+
+const booksNewCollectionDefinition = require('./newCollectionDefinitions/books')
+const booksCollectionDefinition = require('./collectionDefinitions/books')
+const booksEncryptedNewCollectionDefinition = require('./newCollectionDefinitions/books_encrypted')
+const booksEncryptedCollectionDefinition = require('./collectionDefinitions/books_encrypted')
+
+const projectsCollectionDefinition = require('./collectionDefinitions/projects')
+
+const {
+  UPDATERID,
+  UPDATEDAT,
+  CREATORID,
+  CREATEDAT,
+  __STATE__,
+} = require('../lib/consts')
+const { getFieldDefinition } = require('../lib/QueryParser.utils')
+
+tap.test('queryParser utils', t => {
+  t.test('getFieldDefinition', t => {
+    t.test('books collection', t => {
+      const EXPECTED_BOOKS_FIELD_DEFINITION = {
+        _id: 'ObjectId',
+        name: 'string',
+        isbn: 'string',
+        price: 'number',
+        author: 'string',
+        authorAddressId: 'ObjectId',
+        isPromoted: 'boolean',
+        publishDate: 'Date',
+        position: 'GeoPoint',
+        tags: 'Array',
+        tagIds: 'Array',
+        additionalInfo: 'RawObject',
+        signature: 'RawObject',
+        metadata: 'RawObject',
+        attachments: 'Array',
+        editionsDates: 'Array',
+        'signature.name': 'string',
+        'metadata.somethingString': 'string',
+        'metadata.somethingNumber': 'number',
+        'metadata.somethingArrayObject': 'Array',
+        'metadata.somethingArrayObject.arrayItemObjectChildNumber': 'number',
+        'metadata.somethingArrayObject.anotherNumber': 'number',
+        'metadata.somethingArrayObject.anotherObject': 'RawObject',
+        'metadata.somethingObject': 'RawObject',
+        'metadata.somethingObject.childNumber': 'number',
+        'metadata.somethingArrayOfNumbers': 'Array',
+        'metadata.exampleArrayOfArray': 'Array',
+        'attachments.name': 'string',
+        'attachments.detail': 'RawObject',
+        'attachments.detail.size': 'number',
+        'attachments.neastedArr': 'Array',
+        'attachments.additionalInfo': 'RawObject',
+        'attachments.other': 'string',
+        'attachments.size': 'number',
+        'attachments.stuff': 'number',
+        'attachments.more': 'Array',
+        'editionsDates.edition': 'number',
+        'editionsDates.date': 'Date',
+        [UPDATERID]: 'string',
+        [UPDATEDAT]: 'Date',
+        [CREATORID]: 'string',
+        [CREATEDAT]: 'Date',
+        [__STATE__]: 'string',
+      }
+
+      t.test('with legacy definition', t => {
+        const result = getFieldDefinition(booksCollectionDefinition)
+        t.strictSame(result, EXPECTED_BOOKS_FIELD_DEFINITION)
+
+        t.end()
+      })
+
+      t.test('with JSON Schema', t => {
+        const result = getFieldDefinition(booksNewCollectionDefinition)
+        t.strictSame(result, EXPECTED_BOOKS_FIELD_DEFINITION)
+
+        t.end()
+      })
+
+      t.end()
+    })
+
+    t.test('books_encrypted collection', t => {
+      const EXPECTED_BOOKS_ENCRYPTED_FIELD_DEFINITION = {
+        _id: 'ObjectId',
+        name: 'string',
+        isbn: 'string',
+        price: 'number',
+        author: 'string',
+        authorAddressId: 'ObjectId',
+        isPromoted: 'boolean',
+        publishDate: 'Date',
+        position: 'GeoPoint',
+        tags: 'Array',
+        tagIds: 'Array',
+        additionalInfo: 'RawObject',
+        metadata: 'RawObject',
+        attachments: 'Array',
+        editionsDates: 'Array',
+        'metadata.somethingString': 'string',
+        'metadata.somethingNumber': 'number',
+        'metadata.somethingArrayObject': 'Array',
+        'metadata.somethingArrayObject.arrayItemObjectChildNumber': 'number',
+        'metadata.somethingArrayObject.anotherNumber': 'number',
+        'metadata.somethingArrayObject.anotherObject': 'RawObject',
+        'metadata.somethingObject': 'RawObject',
+        'metadata.somethingObject.childNumber': 'number',
+        'metadata.somethingArrayOfNumbers': 'Array',
+        'metadata.exampleArrayOfArray': 'Array',
+        'attachments.name': 'string',
+        'attachments.detail': 'RawObject',
+        'attachments.detail.size': 'number',
+        'attachments.neastedArr': 'Array',
+        'attachments.additionalInfo': 'RawObject',
+        'attachments.other': 'string',
+        'attachments.size': 'number',
+        'attachments.stuff': 'number',
+        'attachments.more': 'Array',
+        [UPDATERID]: 'string',
+        [UPDATEDAT]: 'Date',
+        [CREATORID]: 'string',
+        [CREATEDAT]: 'Date',
+        [__STATE__]: 'string',
+      }
+
+      t.test('with legacy definition', t => {
+        const result = getFieldDefinition(booksEncryptedCollectionDefinition)
+        t.strictSame(result, EXPECTED_BOOKS_ENCRYPTED_FIELD_DEFINITION)
+
+        t.end()
+      })
+
+      t.test('with JSON Schema', t => {
+        const result = getFieldDefinition(booksEncryptedNewCollectionDefinition)
+        t.strictSame(result, EXPECTED_BOOKS_ENCRYPTED_FIELD_DEFINITION)
+
+        t.end()
+      })
+
+      t.end()
+    })
+
+    t.test('projects collection definition', t => {
+      const result = getFieldDefinition(projectsCollectionDefinition)
+      t.strictSame(result, {
+        '_id': 'ObjectId',
+        [CREATORID]: 'string',
+        [CREATEDAT]: 'Date',
+        [UPDATERID]: 'string',
+        [UPDATEDAT]: 'Date',
+        [__STATE__]: 'string',
+        'name': 'string',
+        'environments': 'Array',
+        'environments.label': 'string',
+        'environments.value': 'string',
+        'environments.envId': 'string',
+        'environments.dashboards': 'Array',
+        'environments.dashboards.url': 'string',
+        'environments.dashboards.label': 'string',
+        'environments.dashboards.id': 'string',
+      })
+
+      t.end()
+    })
+
+    t.end()
+  })
+
+  t.end()
+})


### PR DESCRIPTION
<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

## Pull Request Type
<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

<!-- 
    Please include here a description of the Pull Request: what you are modifying, why you are proposing it, why is important..
    Feel free to link a relevant issue that might be affected by your updates.
-->
Including querystring parameter `_useEstimate` in `/count` requests. When used, any other string parameter is ignored and the request of the total amount of documents is executed via `estimatedDocumentCount` of the MongoDB driver, effectively ignoring status and other filtering.

## PR Checklist

<!-- TODO: Include update for the CONTRIBUTING file up-to-date regarding information about the commit -->
- [X] The commit message follows our guidelines included in the [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-submit-a-pr)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Use this space to include more information about your pull request. If you don't need to add anything, feel free to remove this section. -->