### PR TITLE
feat: _useEstimate parameter in count requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Includes query paramater `_useEstimate` on `GET \count` requests to execute the MongoDB `estimatedDocumentCount`   
+
 ### Fixed
 
 - [#237](https://github.com/mia-platform/crud-service/issues/237): casting values in `_q` queries are now even if case of nested fields

--- a/docs/10_Overview_and_Usage.md
+++ b/docs/10_Overview_and_Usage.md
@@ -769,7 +769,7 @@ You can add the parameter `_useEstimate`, to be set to true, to execute the coun
 curl -X GET https://your-url/v2/plates/count?_useEstimate=true -H  "accept: application/json" -H  "content-type: application/json" -H  "client-key: client-key"
 ```
 
-The result will be the total of every document in the collection, regarding the `__STATE__`.
+The result will be the total number of documents in the collection, regardless of their `__STATE__`.
 
 #### Geospatial Queries
 

--- a/docs/10_Overview_and_Usage.md
+++ b/docs/10_Overview_and_Usage.md
@@ -763,6 +763,14 @@ This will return:
 Filters can be applied to the count. By default, only PUBLIC documents are counted.
 :::
 
+You can add the parameter `_useEstimate`, to be set to true, to execute the count request using the collection metadata instead of scanning the entire collection. This method drastically improves speed of the request, but it does not allow to use any filter (any other parameter included will be ignored).
+
+```shell
+curl -X GET https://your-url/v2/plates/count?_useEstimate=true -H  "accept: application/json" -H  "content-type: application/json" -H  "client-key: client-key"
+```
+
+The result will be the total of every document in the collection, regarding the `__STATE__`.
+
 #### Geospatial Queries
 
 On CRUD service, it is possible to filter data also for proximity, using MongoDB Geospatial Queries.

--- a/lib/CrudService.js
+++ b/lib/CrudService.js
@@ -421,7 +421,8 @@ class CrudService {
     return this._mongoCollection.countDocuments(searchQuery, options)
   }
 
-  async estimatedDocumentCount() {
+  async estimatedDocumentCount(context) {
+    context.log.debug({}, 'estimatedDocumentCount operation requested')
     return this._mongoCollection.estimatedDocumentCount()
   }
 

--- a/lib/CrudService.js
+++ b/lib/CrudService.js
@@ -421,6 +421,10 @@ class CrudService {
     return this._mongoCollection.countDocuments(searchQuery, options)
   }
 
+  async estimatedDocumentCount() {
+    return this._mongoCollection.estimatedDocumentCount()
+  }
+
   async deleteAll(context, query, _states) {
     const stateQuery = getStateQuery(_states)
     const isQueryValid = query && Object.keys(query).length > 0

--- a/lib/JSONSchemaGenerator.js
+++ b/lib/JSONSchemaGenerator.js
@@ -51,6 +51,7 @@ const {
   UPDATEDAT,
   CREATORID,
   CREATEDAT,
+  USE_ESTIMATE,
 } = require('./consts')
 const {
   stateCreateValidationSchema,
@@ -121,6 +122,12 @@ module.exports = class JSONSchemaGenerator {
     const countAndQueryValidation = {
       [MONGOID]: { ...mongoIdTypeValidator[idType]() },
       ...structuredClone(deleteProperties),
+      [USE_ESTIMATE]: {
+        type: 'boolean',
+        enum: [true, false],
+        description: 'If `true` returns the count of all documents in the collection, based on the metadata of the collection. It works only there are no other query parameters.',
+        default: false,
+      },
     }
 
     this._idType = idType

--- a/lib/JSONSchemaGenerator.js
+++ b/lib/JSONSchemaGenerator.js
@@ -119,15 +119,9 @@ module.exports = class JSONSchemaGenerator {
       pathFieldsRawSchema
     )
     const deleteProperties = propertiesDeleteValidation(structuredClone(validationGetProperties))
-    const countAndQueryValidation = {
+    const mongoIdAndDeleteProperties = {
       [MONGOID]: { ...mongoIdTypeValidator[idType]() },
       ...structuredClone(deleteProperties),
-      [USE_ESTIMATE]: {
-        type: 'boolean',
-        enum: [true, false],
-        description: 'If `true` returns the count of all documents in the collection, based on the metadata of the collection. It works only there are no other query parameters.',
-        default: false,
-      },
     }
 
     this._idType = idType
@@ -163,8 +157,16 @@ module.exports = class JSONSchemaGenerator {
     }
     this._propertiesPatchQueryValidation = deleteProperties
     this._propertiesFilterChangeStateMany = changeStateProperties
-    this._propertiesCountValidation = { ...countAndQueryValidation }
-    this._propertiesPatchManyQueryValidation = { ...countAndQueryValidation }
+    this._propertiesCountValidation = {
+      ...mongoIdAndDeleteProperties,
+      [USE_ESTIMATE]: {
+        type: 'boolean',
+        enum: [true, false],
+        description: 'If "true", returns the count of all documents in the collection based on the metadata of the collection. It works only there are no other query parameters.',
+        default: false,
+      },
+    }
+    this._propertiesPatchManyQueryValidation = { ...mongoIdAndDeleteProperties }
   }
 
   getSchemaDetail(operationName) {

--- a/lib/consts.js
+++ b/lib/consts.js
@@ -60,6 +60,7 @@ module.exports = Object.freeze({
   STATE: '_st',
   MONGOID: '_id',
   RAW_PROJECTION: '_rawp',
+  USE_ESTIMATE: '_useEstimate',
 
   // Patch commands
   SETCMD: '$set',

--- a/lib/httpInterface.js
+++ b/lib/httpInterface.js
@@ -700,7 +700,7 @@ async function handleCount(request) {
   const { acl_rows } = headers
 
   if (useEstimate) {
-    return this.crudService.estimatedDocumentCount()
+    return this.crudService.estimatedDocumentCount(crudContext)
   }
 
   const mongoQuery = resolveMongoQuery(this.queryParser, clientQueryString, acl_rows, otherParams, false)

--- a/lib/httpInterface.js
+++ b/lib/httpInterface.js
@@ -44,6 +44,7 @@ const {
   __STATE__,
   SCHEMA_CUSTOM_KEYWORDS,
   rawProjectionDictionary,
+  USE_ESTIMATE,
 } = require('./consts')
 
 const getAccept = require('./acceptHeaderParser')
@@ -692,9 +693,15 @@ async function handleCount(request) {
   const {
     [QUERY]: clientQueryString,
     [STATE]: state,
+    [USE_ESTIMATE]: useEstimate,
     ...otherParams
   } = query
+
   const { acl_rows } = headers
+
+  if (useEstimate) {
+    return this.crudService.estimatedDocumentCount()
+  }
 
   const mongoQuery = resolveMongoQuery(this.queryParser, clientQueryString, acl_rows, otherParams, false)
 

--- a/tests/expectedSchemas/booksCountSchema.js
+++ b/tests/expectedSchemas/booksCountSchema.js
@@ -282,6 +282,15 @@ module.exports = {
         'type': 'string',
         'description': 'Additional raw stringified projection for MongoDB',
       },
+      '_useEstimate': {
+        'type': 'boolean',
+        'enum': [
+          true,
+          false,
+        ],
+        'description': 'If "true", returns the count of all documents in the collection based on the metadata of the collection. It works only there are no other query parameters.',
+        'default': false,
+      },
       'signature.name': {
         'type': 'string',
       },

--- a/tests/expectedSchemas/booksNewCountSchema.js
+++ b/tests/expectedSchemas/booksNewCountSchema.js
@@ -312,6 +312,15 @@ module.exports = {
         'type': 'string',
         'description': 'Additional raw stringified projection for MongoDB',
       },
+      '_useEstimate': {
+        'type': 'boolean',
+        'enum': [
+          true,
+          false,
+        ],
+        'description': 'If "true", returns the count of all documents in the collection based on the metadata of the collection. It works only there are no other query parameters.',
+        'default': false,
+      },
       'signature.name': {
         'type': 'string',
       },

--- a/tests/expectedSchemas/carsCountSchema.js
+++ b/tests/expectedSchemas/carsCountSchema.js
@@ -71,6 +71,15 @@ module.exports = {
         'type': 'string',
         'description': 'Additional raw stringified projection for MongoDB',
       },
+      '_useEstimate': {
+        'type': 'boolean',
+        'enum': [
+          true,
+          false,
+        ],
+        'description': 'If "true", returns the count of all documents in the collection based on the metadata of the collection. It works only there are no other query parameters.',
+        'default': false,
+      },
     },
     'additionalProperties': false,
   },

--- a/tests/expectedSchemas/carsNewCountSchema.js
+++ b/tests/expectedSchemas/carsNewCountSchema.js
@@ -91,6 +91,15 @@ module.exports = {
         'type': 'string',
         'description': 'Additional raw stringified projection for MongoDB',
       },
+      '_useEstimate': {
+        'type': 'boolean',
+        'enum': [
+          true,
+          false,
+        ],
+        'description': 'If "true", returns the count of all documents in the collection based on the metadata of the collection. It works only there are no other query parameters.',
+        'default': false,
+      },
     },
     'additionalProperties': false,
   },

--- a/tests/expectedSchemas/stationsCountSchema.js
+++ b/tests/expectedSchemas/stationsCountSchema.js
@@ -112,6 +112,15 @@ module.exports = {
         'type': 'string',
         'description': 'Additional raw stringified projection for MongoDB',
       },
+      '_useEstimate': {
+        'type': 'boolean',
+        'enum': [
+          true,
+          false,
+        ],
+        'description': 'If "true", returns the count of all documents in the collection based on the metadata of the collection. It works only there are no other query parameters.',
+        'default': false,
+      },
     },
     'additionalProperties': false,
   },

--- a/tests/expectedSchemas/stationsNewCountSchema.js
+++ b/tests/expectedSchemas/stationsNewCountSchema.js
@@ -142,6 +142,15 @@ module.exports = {
         'type': 'string',
         'description': 'Additional raw stringified projection for MongoDB',
       },
+      '_useEstimate': {
+        'type': 'boolean',
+        'enum': [
+          true,
+          false,
+        ],
+        'description': 'If "true", returns the count of all documents in the collection based on the metadata of the collection. It works only there are no other query parameters.',
+        'default': false,
+      },
     },
     'additionalProperties': false,
   },

--- a/tests/httpInterface.countList.test.js
+++ b/tests/httpInterface.countList.test.js
@@ -123,6 +123,20 @@ tap.test('HTTP GET /count', async t => {
       acl_rows: undefined,
       count: 0,
     },
+    {
+      name: 'query with _useEstimate parameter',
+      method: 'GET',
+      url: `${prefix}/count?_useEstimate=true`,
+      count: fixtures.length,
+      acl_rows: undefined,
+    },
+    {
+      name: 'query with _useEstimate parameter should ignore other query parameters',
+      method: 'GET',
+      url: `${prefix}/count?_useEstimate=true&_q=${JSON.stringify({ price: { $gt: Infinity } })}`,
+      count: fixtures.length,
+      acl_rows: undefined,
+    },
   ]
 
   t.plan(tests.length)


### PR DESCRIPTION
<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

## Pull Request Type
<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

<!-- 
    Please include here a description of the Pull Request: what you are modifying, why you are proposing it, why is important..
    Feel free to link a relevant issue that might be affected by your updates.
-->
Including querystring parameter `_useEstimate` in `/count` requests. When used, any other string parameter is ignored and the request of the total amount of documents is executed via `estimatedDocumentCount` of the MongoDB driver, effectively ignoring status and other filtering.

## PR Checklist

<!-- TODO: Include update for the CONTRIBUTING file up-to-date regarding information about the commit -->
- [X] The commit message follows our guidelines included in the [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-submit-a-pr)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Use this space to include more information about your pull request. If you don't need to add anything, feel free to remove this section. -->