### PR TITLE
refactor: crud insert many

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Remember to replace `<service name>` with one of the following:
 | k6-stress-test-on-collections  | Executes a Stress Test (GET requests for 90 seconds by 250 users) on the _customers_ collection | [stress-test-on-collections.js](bench/scripts/stress-test-on-collections.js)         |
 | k6-stress-test-on-view         | Executes a Stress Test (GET requests for 90 seconds by 250 users) on the _registered-customers_ view | [stress-test-on-view.js](bench/scripts/stress-test-on-view.js)         |
 | k6-spike-test                  | Executes a Spike Test (simulate a spike of 500 concurrent users for GET requests) on the _customers_ collection | [spike-test.js](bench/scripts/spike-test.js)         |
-| k6-bulk-test                  | Executes a Bulk Test (simulate a spike of 80 bulk requests of 10k records) on the _items_ collection | [bulk-test.js](bench/scripts/bulk-test.js)         |
+| k6-bulk-test                  | Executes a Bulk Test (simulate a spike of 40 `POST /bulk` requests and 40 `PATCH /bulk` requests of 10k records each) on the _items_ collection | [bulk-test.js](bench/scripts/bulk-test.js)         |
 | runner                         | An empty test that can be populated for tests on local environment | [runner.js](bench/scripts/runner.js)         |
 
 We suggest you use the runner to execute customized tests for your research.

--- a/README.md
+++ b/README.md
@@ -362,9 +362,11 @@ Where the script arguments are the following:
 To simplify these operations, you can execute the command `npm run bench:init` from your shell. This command starts a container with a MongoDB 6.0 instance, a container with the CRUD Service (built from your current branch), and populates the _customers_ collection with 100,000 documents.
 
 To execute any test, start the k6 service with the following command:
-```
+
+```bash
 docker compose -f bench/dc-k6.yml up <service name>
 ```
+
 Remember to replace `<service name>` with one of the following:
 | Service Name                   | Description                                                                                     | File name containing the test            | 
 |--------------------------------|-------------------------------------------------------------------------------------------------|------------------------------------------|
@@ -373,6 +375,7 @@ Remember to replace `<service name>` with one of the following:
 | k6-stress-test-on-collections  | Executes a Stress Test (GET requests for 90 seconds by 250 users) on the _customers_ collection | [stress-test-on-collections.js](bench/scripts/stress-test-on-collections.js)         |
 | k6-stress-test-on-view         | Executes a Stress Test (GET requests for 90 seconds by 250 users) on the _registered-customers_ view | [stress-test-on-view.js](bench/scripts/stress-test-on-view.js)         |
 | k6-spike-test                  | Executes a Spike Test (simulate a spike of 500 concurrent users for GET requests) on the _customers_ collection | [spike-test.js](bench/scripts/spike-test.js)         |
+| k6-bulk-test                  | Executes a Bulk Test (simulate a spike of 80 bulk requests of 10k records) on the _items_ collection | [bulk-test.js](bench/scripts/bulk-test.js)         |
 | runner                         | An empty test that can be populated for tests on local environment | [runner.js](bench/scripts/runner.js)         |
 
 We suggest you use the runner to execute customized tests for your research.

--- a/bench/dc-k6.yml
+++ b/bench/dc-k6.yml
@@ -16,6 +16,23 @@ services:
       "json=runner-results.json",
       "/app/runner.js",
     ]
+  k6-bulk-test:
+    image: grafana/k6:0.48.0
+    deploy:
+      resources:
+        limits:
+          memory: 512Mb
+          cpus: "1"
+    volumes:
+      - ./scripts:/app
+    networks:
+      - k6-net
+    command: [ 
+      "run", 
+      "--out",
+      "json=bulk-test-results.json",
+      "/app/bulk-test.js",
+    ]
   k6-load-test:
     image: grafana/k6:0.48.0
     deploy:

--- a/bench/scripts/bulk-test.js
+++ b/bench/scripts/bulk-test.js
@@ -50,7 +50,7 @@ export const options = {
     stages: [
         { duration: '10s', target: 5 },
         { duration: '20s', target: 20 },
-        { duration: '150s', target: 50 },
+        { duration: '80s', target: 40 },
         { duration: '20s', target: 20 },
         { duration: '10s', target: 5 },
     ],
@@ -75,9 +75,26 @@ export default function () {
     
     const postList = http.post(`http://crud-service:3000/items/bulk`, JSON.stringify(items), { 
         headers: { 'Content-Type': 'application/json', 'accept': 'application/json' },
-        tags: { type: 'bulk' }
+        tags: { type: 'post-bulk' }
     })
-    check(postList, { 'POST / returns status 200': res => res.status === 200 }) 
+    check(postList, { 'POST /items/bulk returns status 200': res => res.status === 200 }) 
+    // get ids from post
+    const ids = JSON.parse(postList.body) 
+    // perform patch bulk
+    const patchResult = http.patch(
+        `http://crud-service:3000/items/bulk`, 
+        JSON.stringify(ids.map(({_id}) => ({
+            filter: { _id },
+            update: {$set: {'object.boolean': true}}
+        }))), { 
+        headers: { 'Content-Type': 'application/json' },
+        tags: { type: 'patch-bulk' }
+    })
+    check(patchResult, { 
+        'PATCH /items/bulk returns status 200 after updating all items': (res) => {
+            return res.status === 200 && Number(res.body) === items.length 
+        }
+    }) 
 }
 
 export function teardown(data) {

--- a/bench/scripts/bulk-test.js
+++ b/bench/scripts/bulk-test.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 Mia s.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import http from 'k6/http';
+import { sleep, check } from 'k6';
+import {
+    randomIntBetween,
+    randomString,
+} from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+
+// 
+// This file represent a stub of a k6 test. Feel free to modify based on your needs.
+// 
+
+const generateItems = (length = 10000) => {
+    
+    return Array.from(Array(length).keys()).map((counter) =>({
+        string: randomString(5),
+        number: randomIntBetween(1, 10),
+        boolean: randomIntBetween(0, 1) === 1,
+        date: new Date(randomIntBetween(0, 10)),
+        object: {
+            string: `object-${randomString(5)}`,
+            number: randomIntBetween(1, 10),
+            boolean: randomIntBetween(0, 1) === 1,
+            counter
+        },
+        array: Array.from(Array(randomIntBetween(1, 10)).keys()).map((i) => ({
+            string: `array-${i}-${randomString(5)}`,
+            number: randomIntBetween(1, 10),
+            boolean: randomIntBetween(0, 1) === 1,
+        }))
+    }))
+}
+
+export const options = {
+    stages: [
+        { duration: '10s', target: 5 },
+        { duration: '20s', target: 20 },
+        { duration: '150s', target: 50 },
+        { duration: '20s', target: 20 },
+        { duration: '10s', target: 5 },
+    ],
+    thresholds: {
+        checks: ['rate==1'],
+        http_req_failed: ['rate<0.01'],
+        'http_req_duration{type:bulk}': ['p(90)<4500']
+    }
+}
+
+export function setup() {
+    // Here it goes any code we want to execute before running our tests
+    const getProbe = http.get(`http://crud-service:3000/items/`, { 
+        headers: { 'Content-Type': 'application/json', 'accept': 'application/json' },
+        tags: { type: 'get' }
+    })
+    check(getProbe, { 'GET /items returns status 200': res => res.status === 200 })
+}
+
+export default function () {
+    const items = generateItems()
+    
+    const postList = http.post(`http://crud-service:3000/items/bulk`, JSON.stringify(items), { 
+        headers: { 'Content-Type': 'application/json', 'accept': 'application/json' },
+        tags: { type: 'bulk' }
+    })
+    check(postList, { 'POST / returns status 200': res => res.status === 200 }) 
+}
+
+export function teardown(data) {
+    // Here it goes any code we want to execute after running our tests
+}

--- a/bench/scripts/runner.js
+++ b/bench/scripts/runner.js
@@ -15,27 +15,69 @@
  */
 
 import http from 'k6/http';
-import { sleep } from 'k6';
+import { sleep, check } from 'k6';
+import {
+    randomIntBetween,
+    randomString,
+} from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
 
 // 
 // This file represent a stub of a k6 test. Feel free to modify based on your needs.
 // 
 
+const generateItems = (length = 10000) => {
+    
+    return Array.from(Array(length).keys()).map((counter) =>({
+        string: randomString(5),
+        number: randomIntBetween(1, 10),
+        boolean: randomIntBetween(0, 1) === 1,
+        date: new Date(randomIntBetween(0, 10)),
+        object: {
+            string: `object-${randomString(5)}`,
+            number: randomIntBetween(1, 10),
+            boolean: randomIntBetween(0, 1) === 1,
+            counter
+        },
+        array: Array.from(Array(randomIntBetween(1, 10)).keys()).map((i) => ({
+            string: `array-${i}-${randomString(5)}`,
+            number: randomIntBetween(1, 10),
+            boolean: randomIntBetween(0, 1) === 1,
+        }))
+    }))
+}
+
 export const options = {
     stages: [
-        { duration: '30s', target: 5 },
-        { duration: '2m', target: 10 },
-        { duration: '30s', target: 0 },
+        { duration: '10s', target: 5 },
+        { duration: '20s', target: 20 },
+        { duration: '150s', target: 50 },
+        { duration: '20s', target: 20 },
+        { duration: '10s', target: 5 },
     ],
+    thresholds: {
+        checks: ['rate==1'],
+        http_req_failed: ['rate<0.01'],
+        'http_req_duration{type:bulk}': ['p(90)<4500']
+    }
 }
 
 export function setup() {
     // Here it goes any code we want to execute before running our tests
+    const getProbe = http.get(`http://crud-service:3000/items/`, { 
+        headers: { 'Content-Type': 'application/json', 'accept': 'application/json' },
+        tags: { type: 'get' }
+    })
+    check(getProbe, { 'GET /items returns status 200': res => res.status === 200 })
 }
 
 export default function () {
-    http.get('http://crud-service:3000/users/export?shopID=2')
-    sleep(1)
+    const items = generateItems()
+    
+    const postList = http.post(`http://crud-service:3000/items/bulk`, JSON.stringify(items), { 
+        headers: { 'Content-Type': 'application/json', 'accept': 'application/json' },
+        tags: { type: 'bulk' }
+    })
+    check(postList, { 'POST / returns status 200': res => res.status === 200 }) 
 }
 
 export function teardown(data) {

--- a/lib/CrudService.js
+++ b/lib/CrudService.js
@@ -260,7 +260,7 @@ class CrudService {
       return docs
     }
 
-    return Object.values(writeOpResult.insertedIds)
+    return Object.values(writeOpResult.insertedIds).map((_id) => ({ _id }))
   }
 
   async deleteById(context, id, query, _states) {

--- a/lib/CrudService.js
+++ b/lib/CrudService.js
@@ -250,8 +250,7 @@ class CrudService {
     context.log.debug({ docIds: writeOpResult.insertedIds }, 'insertMany operation executed')
 
     if (!idOnly) {
-      const indexKeys = Object.keys(writeOpResult.insertedIds)
-      for (const indexKey of indexKeys) {
+      for (const indexKey of Object.keys(writeOpResult.insertedIds)) {
         docs[indexKey] = {
           _id: writeOpResult.insertedIds[indexKey],
           ...docs[indexKey],
@@ -364,12 +363,13 @@ class CrudService {
     return writeOpResult
   }
 
-  async upsertMany(context, documents) {
+  async upsertMany(context, documents, queryParser) {
     context.log.debug(documents, 'upsertMany operation requested')
     assert(documents.length > 0, 'At least one element is required')
 
     const operations = []
     for (const document of documents) {
+      queryParser.parseAndCastBody(document)
       assertDocHasNotStandardField(document)
 
       const operation = {

--- a/lib/CrudService.js
+++ b/lib/CrudService.js
@@ -36,10 +36,13 @@ const {
   PUSHCMD,
   ADDTOSETCMD,
   PULLCMD,
+  QUERY,
+  STATE,
 } = require('./consts')
 const { getStateQuery } = require('./CrudService.utils')
 const { JSONPath } = require('jsonpath-plus')
 const { getPathFromPointer } = require('./JSONPath.utils')
+const resolveMongoQuery = require('./resolveMongoQuery')
 
 
 const ALLOWED_COMMANDS = [
@@ -402,24 +405,57 @@ class CrudService {
     return upsertedCount
   }
 
-  async patchBulk(context, filterUpdateCommands) {
+  /**
+   * Performs a patch bulk operation over the CRUD resource
+   * @param {unknown} context
+   * @param {unknown[]} filterUpdateCommands list of commands that needs to be executed
+   * @param {import('./QueryParser')} queryParser
+   * @param {Function} castCollectionId function that casts _id field (if defined in commands)
+   * @param {*} editableFields
+   * @param {*} aclRows
+   * @returns {Promise<number>} the number of modified documents
+   */
+  // eslint-disable-next-line max-statements
+  async patchBulk(
+    context, filterUpdateCommands, queryParser, castCollectionId, editableFields, aclRows
+  ) {
     context.log.debug(filterUpdateCommands, 'patchBulk operation requested')
     assert(filterUpdateCommands.length > 0, 'At least one element is required')
 
     const unorderedBulkOp = this._mongoCollection.initializeUnorderedBulkOp()
+    const parsedAndCastedCommands = new Array(filterUpdateCommands.length)
     for (let i = 0; i < filterUpdateCommands.length; i++) {
-      const { _id, commands, query, state: allowedStates } = filterUpdateCommands[i]
-      const stateQuery = getStateQuery(allowedStates)
-      const isQueryValid = query && Object.keys(query).length > 0
+      const { filter, update } = filterUpdateCommands[i]
+      const {
+        _id,
+        [QUERY]: clientQueryString,
+        [STATE]: state,
+        ...otherParams
+      } = filter
 
-      const searchQuery = isQueryValid ? { $and: [query, stateQuery] } : { $and: [stateQuery] }
+      const commands = update
+
+      const mongoQuery = resolveMongoQuery(queryParser, clientQueryString, aclRows, otherParams, false)
+      queryParser.parseAndCastCommands(commands, editableFields)
+
+      const allowedStates = state.split(',')
+
+      parsedAndCastedCommands[i] = {
+        commands,
+        state: allowedStates,
+        query: mongoQuery,
+      }
+
+      const stateQuery = getStateQuery(allowedStates)
+      const isQueryValid = mongoQuery && Object.keys(mongoQuery).length > 0
+
+      const searchQuery = isQueryValid ? { $and: [mongoQuery, stateQuery] } : { $and: [stateQuery] }
 
       if (_id) {
-        searchQuery.$and.push({ _id })
+        searchQuery.$and.push({ _id: castCollectionId(_id) })
       }
 
       assertCommands(commands)
-
       commands.$set = commands.$set || {}
       commands.$set.updaterId = context.userId
       commands.$set.updatedAt = context.now

--- a/lib/CrudService.js
+++ b/lib/CrudService.js
@@ -96,6 +96,10 @@ function getQueryOptions(crudServiceOptions) {
 class CrudService {
   constructor(mongoCollection, stateOnInsert, defaultSorting, options = {}) {
     assert(STATES_FINITE_STATE_MACHINE[stateOnInsert], 'Invalid `stateOnInsert`')
+
+    /**
+     * @type {import('mongodb').Collection} collection used by this CRUD instance
+     */
     this._mongoCollection = mongoCollection
     this._stateOnInsert = stateOnInsert
     this._defaultSorting = defaultSorting
@@ -218,11 +222,22 @@ class CrudService {
     return doc
   }
 
-  async insertMany(context, docs) {
+  /**
+   * performs a insert many operation over a CRUD resource
+   * @param {unknown} context context of http handler
+   * @param {unknown[]} docs array of documents
+   * @param {import('./QueryParser')} queryParser QueryParser instance
+   * @param {{ idOnly: boolean}?} opts
+   * @returns {Promise<unknown[] | import('mongodb').ObjectId[]>} if flag idOnly is set to true,
+   * returns just the mongodb object ids
+   */
+  async insertMany(context, docs, queryParser, opts = {}) {
+    const { idOnly } = opts
     context.log.debug({ docs }, 'insertMany operation requested')
     assert(docs.length > 0, 'At least one element is required')
 
     for (const doc of docs) {
+      queryParser.parseAndCastBody(doc)
       assertDocHasNotStandardField(doc)
       doc[CREATORID] = context.userId
       doc[UPDATERID] = context.userId
@@ -232,18 +247,20 @@ class CrudService {
     }
 
     const writeOpResult = await this._mongoCollection.insertMany(docs)
+    context.log.debug({ docIds: writeOpResult.insertedIds }, 'insertMany operation executed')
 
-    const indexKeys = Object.keys(writeOpResult.insertedIds)
-    const resultDocs = new Array(indexKeys.length)
-    for (const indexKey of indexKeys) {
-      resultDocs[indexKey] = {
-        _id: writeOpResult.insertedIds[indexKey],
-        ...docs[indexKey],
+    if (!idOnly) {
+      const indexKeys = Object.keys(writeOpResult.insertedIds)
+      for (const indexKey of indexKeys) {
+        docs[indexKey] = {
+          _id: writeOpResult.insertedIds[indexKey],
+          ...docs[indexKey],
+        }
       }
+      return docs
     }
 
-    context.log.debug({ docIds: writeOpResult.insertedIds }, 'insertMany operation executed')
-    return resultDocs
+    return Object.values(writeOpResult.insertedIds)
   }
 
   async deleteById(context, id, query, _states) {

--- a/lib/consts.js
+++ b/lib/consts.js
@@ -132,4 +132,8 @@ module.exports = Object.freeze({
   UNIQUE_INDEX_ERROR_STATUS_CODE: 409,
   UNSUPPORTED_MIME_TYPE_STATUS_CODE: 415,
   INTERNAL_SERVER_ERROR_STATUS_CODE: 500,
+
+  // headers
+  ACL_ROWS: 'acl_rows',
+  ACL_WRITE_COLUMNS: 'acl_write_columns',
 })

--- a/lib/httpInterface.js
+++ b/lib/httpInterface.js
@@ -48,6 +48,8 @@ const {
   UNIQUE_INDEX_ERROR_STATUS_CODE,
   NOT_ACCEPTABLE,
   UNSUPPORTED_MIME_TYPE_STATUS_CODE,
+  ACL_WRITE_COLUMNS,
+  ACL_ROWS,
 } = require('./consts')
 
 const getAccept = require('./acceptHeaderParser')
@@ -57,6 +59,7 @@ const BatchWritableStream = require('./BatchWritableStream')
 const { SCHEMAS_ID } = require('./schemaGetters')
 const { getAjvResponseValidationFunction, shouldValidateStream, shouldValidateItem } = require('./validatorGetters')
 const { getFileMimeParser, getFileMimeStringifiers } = require('./mimeTypeTransform')
+const resolveMongoQuery = require('./resolveMongoQuery')
 
 const OPTIONS_INCOMPATIBILITY_ERROR_CODE = 2
 const UNIQUE_INDEX_MONGO_ERROR_CODE = 11000
@@ -851,40 +854,15 @@ async function handlePatchBulk(request) {
 
   const { body: filterUpdateCommands, crudContext, headers } = request
 
-  const {
-    acl_rows,
-    acl_write_columns: aclWriteColumns,
-  } = headers
 
-  const parsedAndCastedCommands = new Array(filterUpdateCommands.length)
-  for (let i = 0; i < filterUpdateCommands.length; i++) {
-    const { filter, update } = filterUpdateCommands[i]
-    const {
-      _id,
-      [QUERY]: clientQueryString,
-      [STATE]: state,
-      ...otherParams
-    } = filter
-
-    const commands = update
-
-    const editableFields = getEditableFields(aclWriteColumns, this.allFieldNames)
-
-    const mongoQuery = resolveMongoQuery(this.queryParser, clientQueryString, acl_rows, otherParams, false)
-
-    this.queryParser.parseAndCastCommands(commands, editableFields)
-
-    parsedAndCastedCommands[i] = {
-      commands,
-      state: state.split(','),
-      query: mongoQuery,
-    }
-    if (_id) {
-      parsedAndCastedCommands[i].query._id = this.castCollectionId(_id)
-    }
-  }
-
-  const nModified = await this.crudService.patchBulk(crudContext, parsedAndCastedCommands)
+  const nModified = await this.crudService.patchBulk(
+    crudContext,
+    filterUpdateCommands,
+    this.queryParser,
+    this.castCollectionId,
+    getEditableFields(headers[ACL_WRITE_COLUMNS], this.allFieldNames),
+    headers[ACL_ROWS],
+  )
   return nModified
 }
 
@@ -1040,54 +1018,6 @@ async function customErrorHandler(error, request, reply) {
   }
 
   throw error
-}
-
-function resolveMongoQuery(
-  queryParser,
-  clientQueryString,
-  rawAclRows,
-  otherParams,
-  textQuery
-) {
-  const mongoQuery = {
-    $and: [],
-  }
-
-  if (clientQueryString) {
-    const clientQuery = JSON.parse(clientQueryString)
-    mongoQuery.$and.push(clientQuery)
-  }
-  if (otherParams) {
-    for (const key of Object.keys(otherParams)) {
-      const value = otherParams[key]
-      mongoQuery.$and.push({ [key]: value })
-    }
-  }
-
-  if (rawAclRows) {
-    const aclRows = JSON.parse(rawAclRows)
-    if (rawAclRows[0] === '[') {
-      mongoQuery.$and.push({ $and: aclRows })
-    } else {
-      mongoQuery.$and.push(aclRows)
-    }
-  }
-
-  try {
-    if (textQuery) {
-      queryParser.parseAndCastTextSearchQuery(mongoQuery)
-    } else {
-      queryParser.parseAndCast(mongoQuery)
-    }
-  } catch (error) {
-    throw new BadRequestError(error.message)
-  }
-
-  if (!mongoQuery.$and.length) {
-    return {}
-  }
-
-  return mongoQuery
 }
 
 function resolveProjection(clientProjectionString, aclColumns, allFieldNames, rawProjection, log) {

--- a/lib/httpInterface.js
+++ b/lib/httpInterface.js
@@ -341,7 +341,6 @@ async function handleCollectionImport(request, reply) {
     try {
       itemValidator(chunk)
       if (itemValidator.errors) { throw itemValidator.errors }
-      queryParser.parseAndCastBody(chunk)
     } catch (error) {
       return callback(error, chunk)
     }
@@ -351,7 +350,7 @@ async function handleCollectionImport(request, reply) {
 
   // POST
   let returnCode = 201
-  let processBatch = async(batch) => crudService.insertMany(crudContext, batch)
+  let processBatch = async(batch) => crudService.insertMany(crudContext, batch, queryParser)
 
   // PATCH
   if (request.method === 'PATCH') {
@@ -899,11 +898,13 @@ async function handleInsertMany(request, reply) {
 
   const { body: docs, crudContext } = request
 
-  docs.forEach(this.queryParser.parseAndCastBody)
-
   try {
-    const insertedDocs = await this.crudService.insertMany(crudContext, docs)
-    return insertedDocs.map(mapToObjectWithOnlyId)
+    return this.crudService.insertMany(
+      crudContext,
+      docs,
+      this.queryParser,
+      { idOnly: true }
+    )
   } catch (error) {
     if (error.code === UNIQUE_INDEX_MONGO_ERROR_CODE) {
       request.log.error('unique index violation')

--- a/lib/httpInterface.js
+++ b/lib/httpInterface.js
@@ -356,7 +356,7 @@ async function handleCollectionImport(request, reply) {
   if (request.method === 'PATCH') {
     returnCode = 200
     processBatch = async(batch) => {
-      return crudService.upsertMany(crudContext, batch)
+      return crudService.upsertMany(crudContext, batch, queryParser)
     }
   }
 

--- a/lib/httpInterface.js
+++ b/lib/httpInterface.js
@@ -899,12 +899,13 @@ async function handleInsertMany(request, reply) {
   const { body: docs, crudContext } = request
 
   try {
-    return this.crudService.insertMany(
+    const ids = await this.crudService.insertMany(
       crudContext,
       docs,
       this.queryParser,
       { idOnly: true }
     )
+    return ids
   } catch (error) {
     if (error.code === UNIQUE_INDEX_MONGO_ERROR_CODE) {
       request.log.error('unique index violation')

--- a/lib/httpInterface.js
+++ b/lib/httpInterface.js
@@ -298,6 +298,12 @@ module.exports = async function getHttpInterface(fastify, options) {
 
     fastify.log.debug({ collection: fastify?.modelName }, 'getters endpoints registered')
   }
+
+  fastify.addHook('onRequest', async(request) => {
+    if (request.headers.acl_rows) {
+      request.headers.acl_rows = JSON.parse(request.headers.acl_rows)
+    }
+  })
 }
 
 // eslint-disable-next-line max-statements

--- a/lib/resolveMongoQuery.js
+++ b/lib/resolveMongoQuery.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const BadRequestError = require('./BadRequestError')
+
+/**
+ * This function resolves a mongodb query that has to be performed over a CRUD resource.
+ *
+ * @param {import('./QueryParser')} queryParser the QueryParser istance
+ * @param {string?} clientQueryString the raw string representing a mongodb query
+ * @param {string?} rawAclRows acl expression for rows filtering
+ * @param {unknown?} otherParams additional parameters that will be appended to the query with $and operator
+ * @param {boolean} textQuery if the query that needs to be resolved contains a text filter
+ * @returns {import('mongodb').Document} mongodb query
+ */
+function resolveMongoQuery(
+  queryParser,
+  clientQueryString,
+  rawAclRows,
+  otherParams,
+  textQuery
+) {
+  const mongoQuery = {
+    $and: [],
+  }
+
+  if (clientQueryString) {
+    const clientQuery = JSON.parse(clientQueryString)
+    mongoQuery.$and.push(clientQuery)
+  }
+  if (otherParams) {
+    for (const key of Object.keys(otherParams)) {
+      const value = otherParams[key]
+      mongoQuery.$and.push({ [key]: value })
+    }
+  }
+
+  if (rawAclRows) {
+    const aclRows = JSON.parse(rawAclRows)
+    if (rawAclRows[0] === '[') {
+      mongoQuery.$and.push({ $and: aclRows })
+    } else {
+      mongoQuery.$and.push(aclRows)
+    }
+  }
+
+  try {
+    if (textQuery) {
+      queryParser.parseAndCastTextSearchQuery(mongoQuery)
+    } else {
+      queryParser.parseAndCast(mongoQuery)
+    }
+  } catch (error) {
+    throw new BadRequestError(error.message)
+  }
+
+  if (!mongoQuery.$and.length) {
+    return {}
+  }
+
+  return mongoQuery
+}
+
+module.exports = resolveMongoQuery

--- a/lib/resolveMongoQuery.js
+++ b/lib/resolveMongoQuery.js
@@ -7,7 +7,7 @@ const BadRequestError = require('./BadRequestError')
  *
  * @param {import('./QueryParser')} queryParser the QueryParser istance
  * @param {string?} clientQueryString the raw string representing a mongodb query
- * @param {string?} rawAclRows acl expression for rows filtering
+ * @param {unknown?} aclRows acl expression for rows filtering
  * @param {unknown?} otherParams additional parameters that will be appended to the query with $and operator
  * @param {boolean} textQuery if the query that needs to be resolved contains a text filter
  * @returns {import('mongodb').Document} mongodb query
@@ -15,7 +15,7 @@ const BadRequestError = require('./BadRequestError')
 function resolveMongoQuery(
   queryParser,
   clientQueryString,
-  rawAclRows,
+  aclRows,
   otherParams,
   textQuery
 ) {
@@ -34,9 +34,8 @@ function resolveMongoQuery(
     }
   }
 
-  if (rawAclRows) {
-    const aclRows = JSON.parse(rawAclRows)
-    if (rawAclRows[0] === '[') {
+  if (aclRows) {
+    if (Array.isArray(aclRows)) {
       mongoQuery.$and.push({ $and: aclRows })
     } else {
       mongoQuery.$and.push(aclRows)

--- a/package.json
+++ b/package.json
@@ -100,6 +100,12 @@
           "id-length": "off",
           "max-lines": "off"
         }
+      },
+      {
+        "files": ["lib/**/*.js"],
+        "rules": {
+          "valid-jsdoc": "off"
+        }
       }
     ]
   },

--- a/tests/insertOneWithId.test.js
+++ b/tests/insertOneWithId.test.js
@@ -116,7 +116,8 @@ t.test('insertOneWithId', async t => {
       t.plan(1)
 
       try {
-        await crudService.insertMany(context, [{ ...DOC, [standardField]: 'some truly value' }])
+        // eslint-disable-next-line no-empty-function
+        await crudService.insertMany(context, [{ ...DOC, [standardField]: 'some truly value' }], { parseAndCastBody: () => {} })
         t.fail()
       } catch (error) {
         t.equal(error.message, `${standardField} cannot be specified`)


### PR DESCRIPTION
<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

## Pull Request Type
<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

<!-- 
    Please include here a description of the Pull Request: what you are modifying, why you are proposing it, why is important..
    Feel free to link a relevant issue that might be affected by your updates.
-->

This PR improves the performances of the `POST /bulk` operation, by avoiding to create multiple copies of the batch that has to be inserted.

## PR Checklist

<!-- TODO: Include update for the CONTRIBUTING file up-to-date regarding information about the commit -->
- [x] The commit message follows our guidelines included in the [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-submit-a-pr)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Use this space to include more information about your pull request. If you don't need to add anything, feel free to remove this section. -->

A k6 test has been added on the `bench/scripts` folder, named `bulk-test.js`. In this test, 10k records are inserted in batches into the records folder, using up to 80 concurrent requests.

This is the outcome for the version from the current branch:

```
✓ checks.........................: 100.00% ✓ 14       ✗ 0   
data_received..................: 4.9 MB  18 kB/s
data_sent......................: 65 MB   235 kB/s
http_req_blocked...............: avg=180.18ms min=6.55µs   med=141.76ms max=499.23ms p(90)=416.23ms p(95)=449.42ms
http_req_connecting............: avg=179.51ms min=0s       med=141.63ms max=498.16ms p(90)=414.17ms p(95)=447.17ms
http_req_duration..............: avg=2.29s    min=19.39ms  med=1.96s    max=5.56s    p(90)=4.1s     p(95)=4.73s   
  { expected_response:true }...: avg=2.29s    min=19.39ms  med=1.96s    max=5.56s    p(90)=4.1s     p(95)=4.73s   
✓ { type:bulk }................: avg=2.46s    min=787.93ms med=2.2s     max=5.56s    p(90)=4.16s    p(95)=4.79s   
✓ http_req_failed................: 0.00%   ✓ 0        ✗ 14  
http_req_receiving.............: avg=220.31ms min=910.4µs  med=4.75ms   max=2s       p(90)=519.01ms p(95)=1.07s   
http_req_sending...............: avg=993.43ms min=42.51µs  med=701.65ms max=3.56s    p(90)=2.33s    p(95)=2.85s   
http_req_tls_handshaking.......: avg=0s       min=0s       med=0s       max=0s       p(90)=0s       p(95)=0s      
http_req_waiting...............: avg=1.08s    min=17.93ms  med=1.15s    max=1.62s    p(90)=1.46s    p(95)=1.52s   
http_reqs......................: 14      0.050999/s
iteration_duration.............: avg=47.84s   min=332.17µs med=34.37s   max=3m3s     p(90)=1m39s    p(95)=2m6s    
iterations.....................: 13      0.047356/s
vus............................: 0       min=0      max=50
vus_max........................: 50      min=50     max=50
```