### PR TITLE
fix(query-parser): review regex to allow digits in _q field names

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,10 @@ jobs:
         run: npm ci
 
       - name: update libraries and install curl
-        run: sudo apt-get update && sudo apt-get install curl -y
+        # temporary workaround for https://github.com/actions/runner-images/issues/9733
+        run: |
+          sudo rm /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update && sudo apt-get install curl -y
 
       - name: download MongoDB encryption libraries (to support testing encryption features)
         run: curl https://repo.mongodb.com/apt/debian/dists/bullseye/mongodb-enterprise/6.0/main/binary-amd64/mongodb-enterprise-cryptd_6.0.9_amd64.deb -o mongocryptd.deb && curl https://libmongocrypt.s3.amazonaws.com/apt/debian/dists/bullseye/libmongocrypt/1.7/main/binary-amd64/libmongocrypt-dev_1.7.4-0_amd64.deb -o libmongocrypt-dev.deb && curl https://libmongocrypt.s3.amazonaws.com/apt/debian/dists/bullseye/libmongocrypt/1.7/main/binary-amd64/libmongocrypt0_1.7.4-0_amd64.deb -o libmongocrypt0.deb
@@ -73,7 +76,10 @@ jobs:
         run: npm ci
 
       - name: update libraries and install curl
-        run: sudo apt-get update && sudo apt-get install curl -y
+        # temporary workaround for https://github.com/actions/runner-images/issues/9733
+        run: |
+          sudo rm /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update && sudo apt-get install curl -y
 
       - name: download MongoDB encryption libraries (to support testing encryption features)
         run: curl https://repo.mongodb.com/apt/debian/dists/bullseye/mongodb-enterprise/7.0/main/binary-amd64/mongodb-enterprise-cryptd_7.0.2_amd64.deb -o mongocryptd.deb && curl https://libmongocrypt.s3.amazonaws.com/apt/debian/dists/bullseye/libmongocrypt/1.8/main/binary-amd64/libmongocrypt-dev_1.8.2-0_amd64.deb -o libmongocrypt-dev.deb && curl https://libmongocrypt.s3.amazonaws.com/apt/debian/dists/bullseye/libmongocrypt/1.8/main/binary-amd64/libmongocrypt0_1.8.2-0_amd64.deb -o libmongocrypt0.deb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed 
+
+- allow running raw queries with `_q` over fields containing a digit in their name
+
 ## 7.0.1 - 2024-04-08
 
 ### Added

--- a/lib/QueryParser.utils.js
+++ b/lib/QueryParser.utils.js
@@ -21,8 +21,12 @@
 const { DATE_FORMATS, DATE, JSON_SCHEMA_OBJECT_TYPE, RAWOBJECTTYPE, JSON_SCHEMA_ARRAY_TYPE, ARRAY } = require('./consts')
 
 function getFieldDefinitionNameFromQuery(query = '') {
+  // here are removed only the index identifiers from the potentially nested field name
+  // (for example 'field-a.2.message' becomes 'field-a.message'
+  // the regex requires that the chunk starts and ends with a digit,
+  // allowing collection fields to contain digits in their name
   return query.split('.')
-    .filter(chunk => !/[\d]+/.test(chunk))
+    .filter(chunk => !/^\d+$/.test(chunk))
     .join('.')
 }
 

--- a/tests/queryParser.utils.test.js
+++ b/tests/queryParser.utils.test.js
@@ -32,7 +32,7 @@ const {
   CREATEDAT,
   __STATE__,
 } = require('../lib/consts')
-const { getFieldDefinition } = require('../lib/QueryParser.utils')
+const { getFieldDefinition, getFieldDefinitionNameFromQuery } = require('../lib/QueryParser.utils')
 
 tap.test('queryParser utils', t => {
   t.test('getFieldDefinition', t => {
@@ -187,4 +187,51 @@ tap.test('queryParser utils', t => {
   })
 
   t.end()
+})
+
+
+tap.test('getFieldDefinitionNameFromQuery', async t => {
+  const testCases = [
+    {
+      description: 'parse root level field',
+      input: 'ciaone',
+      output: 'ciaone',
+    },
+    {
+      description: 'parse root level field with digit inside',
+      input: 'up2you',
+      output: 'up2you',
+    },
+    {
+      description: 'parse root level field with digit at the end',
+      input: 'level1',
+      output: 'level1',
+    },
+    {
+      description: 'parse nested level field',
+      input: 'configuration.consumer',
+      output: 'configuration.consumer',
+    },
+    {
+      description: 'parse multiple nested level field',
+      input: 'configuration.consumer.broker.id',
+      output: 'configuration.consumer.broker.id',
+    },
+    {
+      description: 'parse nested level where array index is removed',
+      input: 'orders.1.productId',
+      output: 'orders.productId',
+    },
+    {
+      description: 'parse nested level where array index is removed | digit in name is untouched',
+      input: 'orders2.1.productId',
+      output: 'orders2.productId',
+    },
+  ]
+
+  testCases.forEach(testCase => {
+    t.test(testCase.description, async assert => {
+      assert.strictSame(getFieldDefinitionNameFromQuery(testCase.input), testCase.output)
+    })
+  })
 })


### PR DESCRIPTION
<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

This PR reviews a check on the CRUD Service that prevented the usage of fields with digits in the `_q` query parameter.

## Pull Request Type
<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

<!-- 
    Please include here a description of the Pull Request: what you are modifying, why you are proposing it, why is important..
    Feel free to link a relevant issue that might be affected by your updates.
-->

## PR Checklist

<!-- TODO: Include update for the CONTRIBUTING file up-to-date regarding information about the commit -->
- [X] The commit message follows our guidelines included in the [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-submit-a-pr)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
